### PR TITLE
Add driver mode to REST requests

### DIFF
--- a/test/test_conversion_c2sql_boolean.cc
+++ b/test/test_conversion_c2sql_boolean.cc
@@ -31,7 +31,8 @@ TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -51,7 +52,8 @@ TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -71,7 +73,8 @@ TEST_F(ConvertC2SQL_Boolean, Smallint2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Smallint2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -91,7 +94,8 @@ TEST_F(ConvertC2SQL_Boolean, UShort2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"UShort2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -111,7 +115,8 @@ TEST_F(ConvertC2SQL_Boolean, LongLong2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"LongLong2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -131,7 +136,8 @@ TEST_F(ConvertC2SQL_Boolean, Float2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -151,7 +157,8 @@ TEST_F(ConvertC2SQL_Boolean, Double2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -176,7 +183,8 @@ TEST_F(ConvertC2SQL_Boolean, Numeric2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -197,7 +205,8 @@ TEST_F(ConvertC2SQL_Boolean, Binary2Boolean) /* note: name used in test */
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Binary2Boolean\", "
-		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}]}");
+		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_numeric.cc
+++ b/test/test_conversion_c2sql_numeric.cc
@@ -31,7 +31,8 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Short2Integer)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Short2Integer\", "
-		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}]}");
+		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -85,7 +86,8 @@ TEST_F(ConvertC2SQL_Numeric, CStr_LLong2Long)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
-		"\"value\": 9223372036854775807}]}");
+		"\"value\": 9223372036854775807}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -124,7 +126,8 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Float2Long)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
-		"\"value\": 9223372036854775806.12345}]}");
+		"\"value\": 9223372036854775806.12345}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -145,7 +148,8 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Byte2Integer)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Byte2Integer\", "
-		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}]}");
+		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -167,7 +171,8 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2HFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
-		"\"value\": -12345678901234567890.123456789}]}");
+		"\"value\": -12345678901234567890.123456789}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -189,7 +194,8 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2SFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
-		"\"value\": -12345678901234567890.123456789}]}");
+		"\"value\": -12345678901234567890.123456789}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -226,7 +232,8 @@ TEST_F(ConvertC2SQL_Numeric, Short2Integer)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Integer\", "
-		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}]}");
+		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -248,7 +255,8 @@ TEST_F(ConvertC2SQL_Numeric, LLong2Long)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
-		"\"value\": 9223372036854775807}]}");
+		"\"value\": 9223372036854775807}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -287,7 +295,8 @@ TEST_F(ConvertC2SQL_Numeric, Float2Long)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
-		"\"value\": 9.2233720368548e+18}]}");
+		"\"value\": 9.2233720368548e+18}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -308,7 +317,8 @@ TEST_F(ConvertC2SQL_Numeric, Byte2Integer)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Byte2Integer\", "
-		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}]}");
+		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -330,7 +340,8 @@ TEST_F(ConvertC2SQL_Numeric, Double2HFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
-		"\"value\": -1.23456789e+19}]}"); /* def prec is 8 */
+		"\"value\": -1.23456789e+19}], " /* def prec is 8 */
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -352,7 +363,8 @@ TEST_F(ConvertC2SQL_Numeric, Double2SFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
-		"\"value\": -1.234567890123456717e+19}]}");
+		"\"value\": -1.234567890123456717e+19}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -391,7 +403,8 @@ TEST_F(ConvertC2SQL_Numeric, Bin_LLong2Long)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
-		"\"value\": 9223372036854775807}]}");
+		"\"value\": 9223372036854775807}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -431,7 +444,8 @@ TEST_F(ConvertC2SQL_Numeric, Bin_Double2SFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
-		"\"value\": -1.234567890123456717e+19}]}");
+		"\"value\": -1.234567890123456717e+19}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -458,7 +472,8 @@ TEST_F(ConvertC2SQL_Numeric, Numeric2HFloat)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
-		"\"value\": -2.5212e+01}]}");
+		"\"value\": -2.5212e+01}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -82,7 +82,8 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_16)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_16\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"1234-12-23T12:34:00Z\"}]}");
+		"\"value\": \"1234-12-23T12:34:00Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -105,7 +106,8 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_19)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_19\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"1234-12-23T12:34:56Z\"}]}");
+		"\"value\": \"1234-12-23T12:34:56Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -144,7 +146,8 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_trim)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_trim\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"1234-12-23T12:34:56.78901Z\"}]}");
+		"\"value\": \"1234-12-23T12:34:56.78901Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -167,7 +170,8 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_full)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_full\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"1234-12-23T12:34:56.7890123Z\"}]}");
+		"\"value\": \"1234-12-23T12:34:56.7890123Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -197,7 +201,8 @@ TEST_F(ConvertC2SQL_Timestamp, Timestamp2Timestamp_decdigits_7)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Timestamp2Timestamp_decdigits_7\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"2345-01-23T12:34:56.7890123Z\"}]}");
+		"\"value\": \"2345-01-23T12:34:56.7890123Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -228,7 +233,8 @@ TEST_F(ConvertC2SQL_Timestamp, Binary2Timestamp_colsize_0)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Binary2Timestamp_colsize_0\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"2345-01-23T12:34:56.789Z\"}]}");
+		"\"value\": \"2345-01-23T12:34:56.789Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -255,7 +261,8 @@ TEST_F(ConvertC2SQL_Timestamp, Date2Timestamp)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Date2Timestamp\", "
 		"\"params\": [{\"type\": \"DATE\", "
-		"\"value\": \"2345-01-23T00:00:00.000Z\"}]}");
+		"\"value\": \"2345-01-23T00:00:00.000Z\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_varchar.cc
+++ b/test/test_conversion_c2sql_varchar.cc
@@ -33,7 +33,8 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_empty)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"\"}]}");
+		"\"value\": \"\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -56,7 +57,8 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_empty)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"\"}]}");
+		"\"value\": \"\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -79,7 +81,8 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr2Varchar_ansi\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"0123abcABC\"}]}");
+		"\"value\": \"0123abcABC\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -102,7 +105,8 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"0123abcABC\"}]}");
+		"\"value\": \"0123abcABC\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -125,7 +129,8 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi_jsonescape)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr2Varchar_ansi_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]}");
+		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -148,7 +153,8 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr2Varchar_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]}");
+		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -171,7 +177,8 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_jsonescape)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr2Varchar_u8_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}]}");
+		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -194,7 +201,8 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape)
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr2Varchar_u8_fullescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}]}");
+		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -215,7 +223,8 @@ TEST_F(ConvertC2SQL_Varchar, Short2Varchar)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Varchar\", "
-		"\"params\": [{\"type\": \"KEYWORD\", \"value\": \"-12345\"}]}");
+		"\"params\": [{\"type\": \"KEYWORD\", \"value\": \"-12345\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -237,7 +246,8 @@ TEST_F(ConvertC2SQL_Varchar, Bigint2Varchar)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bigint2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"9223372036854775807\"}]}");
+		"\"value\": \"9223372036854775807\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -276,7 +286,8 @@ TEST_F(ConvertC2SQL_Varchar, Double2Varchar)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
-		"\"value\": \"1.2000e+00\"}]}");
+		"\"value\": \"1.2000e+00\"}], "
+		"\"mode\": \"ODBC\"}");
 
 	ASSERT_CSTREQ(buff, expect);
 }


### PR DESCRIPTION
- add "mode": "ODBC" to every JSON REST request, to inform the SQL
plugin about the requester.

This adds support for late ES/SQL corresponding feature merged shortly before FF.