### PR TITLE
Attempting to remove using the MSI and not using the control panel

### DIFF
--- a/installer/src/Installer/Program.cs
+++ b/installer/src/Installer/Program.cs
@@ -100,11 +100,11 @@ namespace ODBCInstaller
 						Windows Server 2016:	VersionNT64 = 1000 AND MsiNTProductType <> 1 
 					*/
 					new LaunchCondition(
-						"NOT ((VersionNT64 = 1000 AND MsiNTProductType = 1) OR (VersionNT64 = 1000 AND MsiNTProductType <> 1))",
+						"Installed OR (NOT ((VersionNT64 = 1000 AND MsiNTProductType = 1) OR (VersionNT64 = 1000 AND MsiNTProductType <> 1)))",
 						"This installer requires at least Windows 10 or Windows Server 2016."
 					),
 					new LaunchCondition(
-						"VS2017REDISTINSTALLED",
+						"Installed OR VS2017REDISTINSTALLED",
 						"This installer requires the Visual C++ 2017 Redistributable. " +
 						"Please install Visual C++ 2017 Redistributable and then run this installer again."
 					),


### PR DESCRIPTION
Attempting to remove using the MSI and not using the control panel gives an error saying I need VC 2017 C++ libraries installed. Fix is to bypass the LaunchCondition checks if the product is already installed. Fixes #49