### PR TITLE
ODBC request mode only added for catalog queries. New client_id request param.

### DIFF
--- a/driver/catalogue.c
+++ b/driver/catalogue.c
@@ -123,7 +123,7 @@ SQLSMALLINT copy_current_catalog(esodbc_dbc_st *dbc, SQLWCHAR *dest,
 	assert(stmt);
 
 	if (! SQL_SUCCEEDED(attach_sql(stmt, MK_WPTR(SYS_CATALOGS),
-				sizeof(SYS_CATALOGS) - 1))) {
+				sizeof(SYS_CATALOGS) - 1, /*is catalog*/TRUE))) {
 		ERRH(dbc, "failed to attach query to statement.");
 		goto end;
 	}
@@ -403,7 +403,7 @@ SQLRETURN EsSQLTablesW(
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuf, pos);
+	ret = attach_sql(stmt, wbuf, pos, /*is_catalog*/TRUE);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}
@@ -539,7 +539,7 @@ SQLRETURN EsSQLColumnsW
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuf, pos);
+	ret = attach_sql(stmt, wbuf, pos, /*is_catalog*/TRUE);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -301,6 +301,7 @@ typedef struct struct_stmt {
 
 	/* cache UTF8 JSON serialized SQL: can be (re)used with varying params */
 	cstr_st u8sql;
+	BOOL is_catalog; /* statment is for a catalog query */
 
 	/* pointers to the current descriptors */
 	esodbc_desc_st *ard;

--- a/driver/info.c
+++ b/driver/info.c
@@ -1211,7 +1211,7 @@ SQLRETURN EsSQLGetTypeInfoW(SQLHSTMT StatementHandle, SQLSMALLINT DataType)
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuff, cnt);
+	ret = attach_sql(stmt, wbuff, cnt, /*is_catalog*/TRUE);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -14,7 +14,7 @@ SQLRETURN TEST_API attach_answer(esodbc_stmt_st *stmt, char *buff,
 	size_t blen);
 SQLRETURN TEST_API attach_error(SQLHANDLE hnd, cstr_st *body, int code);
 SQLRETURN TEST_API attach_sql(esodbc_stmt_st *stmt, const SQLWCHAR *sql,
-	size_t tlen);
+	size_t tlen, BOOL is_catalog);
 void detach_sql(esodbc_stmt_st *stmt);
 SQLRETURN TEST_API serialize_statement(esodbc_stmt_st *stmt, cstr_st *buff);
 

--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -27,7 +27,9 @@ extern "C" {
 
 /* convenience casting macros */
 #define ATTACH_ANSWER(_h, _s, _l)   attach_answer((esodbc_stmt_st *)_h, _s, _l)
-#define ATTACH_SQL(_h, _s, _l)      attach_sql((esodbc_stmt_st *)_h, _s, _l)
+#define ATTACH_SQL(_h, _s, _l)      \
+	/* is_catalog set to TRUE, since all tests expect the mode param */ \
+	attach_sql((esodbc_stmt_st *)_h, _s, _l, TRUE)
 
 #define ASSERT_CSTREQ(_c1, _c2) \
 	do { \

--- a/test/test_conversion_c2sql_boolean.cc
+++ b/test/test_conversion_c2sql_boolean.cc
@@ -9,6 +9,11 @@
 
 #include <string.h>
 
+#ifdef _WIN64
+#	define CLIENT_ID	"\"client_id\": \"odbc64\""
+#else /* _WIN64 */
+#	define CLIENT_ID	"\"client_id\": \"odbc32\""
+#endif /* _WIN64 */
 
 namespace test {
 
@@ -32,7 +37,7 @@ TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -53,7 +58,7 @@ TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -74,7 +79,7 @@ TEST_F(ConvertC2SQL_Boolean, Smallint2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Smallint2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -95,7 +100,7 @@ TEST_F(ConvertC2SQL_Boolean, UShort2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"UShort2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -116,7 +121,7 @@ TEST_F(ConvertC2SQL_Boolean, LongLong2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"LongLong2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -137,7 +142,7 @@ TEST_F(ConvertC2SQL_Boolean, Float2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -158,7 +163,7 @@ TEST_F(ConvertC2SQL_Boolean, Double2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -184,7 +189,7 @@ TEST_F(ConvertC2SQL_Boolean, Numeric2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -206,7 +211,7 @@ TEST_F(ConvertC2SQL_Boolean, Binary2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Binary2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_interval.cc
+++ b/test/test_conversion_c2sql_interval.cc
@@ -9,6 +9,12 @@
 
 #include <string.h>
 
+#ifdef _WIN64
+#	define CLIENT_ID	"\"client_id\": \"odbc64\""
+#else /* _WIN64 */
+#	define CLIENT_ID	"\"client_id\": \"odbc32\""
+#endif /* _WIN64 */
+
 
 namespace test {
 
@@ -32,7 +38,7 @@ TEST_F(ConvertC2SQL_Interval, Bit2Interval_year)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bit2Interval_year\", "
 		"\"params\": [{\"type\": \"INTERVAL_YEAR\", "
 		"\"value\": \"P1Y\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -54,7 +60,7 @@ TEST_F(ConvertC2SQL_Interval, Short2Interval_month)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Interval_month\", "
 		"\"params\": [{\"type\": \"INTERVAL_MONTH\", "
 		"\"value\": \"P-2M\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -76,7 +82,7 @@ TEST_F(ConvertC2SQL_Interval, Short2Interval_month_all_0)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Interval_month_all_0\", "
 		"\"params\": [{\"type\": \"INTERVAL_MONTH\", "
 		"\"value\": \"P0M\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -98,7 +104,7 @@ TEST_F(ConvertC2SQL_Interval, Integer2Interval_day)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Integer2Interval_day\", "
 		"\"params\": [{\"type\": \"INTERVAL_DAY\", "
 		"\"value\": \"P-3D\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -120,7 +126,7 @@ TEST_F(ConvertC2SQL_Interval, UBigInt2Interval_minute)
 	cstr_st expect = CSTR_INIT("{\"query\": \"UBigInt2Interval_minute\", "
 		"\"params\": [{\"type\": \"INTERVAL_MINUTE\", "
 		"\"value\": \"PT12345678M\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -142,7 +148,7 @@ TEST_F(ConvertC2SQL_Interval, SBigInt2Interval_second)
 	cstr_st expect = CSTR_INIT("{\"query\": \"SBigInt2Interval_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_SECOND\", "
 		"\"value\": \"PT-123456789S\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -165,7 +171,7 @@ TEST_F(ConvertC2SQL_Interval, SBigInt2Interval_second_all_0)
 		"{\"query\": \"SBigInt2Interval_second_all_0\", "
 		"\"params\": [{\"type\": \"INTERVAL_SECOND\", "
 		"\"value\": \"PT0S\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -188,7 +194,7 @@ TEST_F(ConvertC2SQL_Interval, WChar2Interval_day_to_second)
 		"{\"query\": \"WChar2Interval_day_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_DAY_TO_SECOND\", "
 		"\"value\": \"P-2DT-3H-4M-5.678S\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -211,7 +217,7 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second)
 		"{\"query\": \"Char2Interval_hour_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -238,7 +244,7 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second_force_alloc)
 		"{\"query\": \"Char2Interval_hour_to_second_force_alloc\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -266,7 +272,7 @@ TEST_F(ConvertC2SQL_Interval, Interval2Interval_year_to_month)
 		"{\"query\": \"Interval2Interval_year_to_month\", "
 		"\"params\": [{\"type\": \"INTERVAL_YEAR_TO_MONTH\", "
 		"\"value\": \"P-12Y-11M\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_numeric.cc
+++ b/test/test_conversion_c2sql_numeric.cc
@@ -9,6 +9,12 @@
 
 #include <string.h>
 
+#ifdef _WIN64
+#	define CLIENT_ID	"\"client_id\": \"odbc64\""
+#else /* _WIN64 */
+#	define CLIENT_ID	"\"client_id\": \"odbc32\""
+#endif /* _WIN64 */
+
 
 namespace test {
 
@@ -32,7 +38,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Short2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Short2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -87,7 +93,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -127,7 +133,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Float2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775806.12345}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -149,7 +155,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Byte2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Byte2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -172,7 +178,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -12345678901234567890.123456789}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -195,7 +201,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -12345678901234567890.123456789}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -233,7 +239,7 @@ TEST_F(ConvertC2SQL_Numeric, Short2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -256,7 +262,7 @@ TEST_F(ConvertC2SQL_Numeric, LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -296,7 +302,7 @@ TEST_F(ConvertC2SQL_Numeric, Float2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9.2233720368548e+18}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -318,7 +324,7 @@ TEST_F(ConvertC2SQL_Numeric, Byte2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Byte2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -341,7 +347,7 @@ TEST_F(ConvertC2SQL_Numeric, Double2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -1.23456789e+19}], " /* def prec is 8 */
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -364,7 +370,7 @@ TEST_F(ConvertC2SQL_Numeric, Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -1.234567890123456717e+19}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -404,7 +410,7 @@ TEST_F(ConvertC2SQL_Numeric, Bin_LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -445,7 +451,7 @@ TEST_F(ConvertC2SQL_Numeric, Bin_Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -1.234567890123456717e+19}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -473,7 +479,7 @@ TEST_F(ConvertC2SQL_Numeric, Numeric2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -2.5212e+01}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -9,6 +9,12 @@
 
 #include <string.h>
 
+#ifdef _WIN64
+#	define CLIENT_ID	"\"client_id\": \"odbc64\""
+#else /* _WIN64 */
+#	define CLIENT_ID	"\"client_id\": \"odbc32\""
+#endif /* _WIN64 */
+
 
 namespace test {
 
@@ -83,7 +89,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_16)
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_16\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"1234-12-23T12:34:00Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -107,7 +113,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_19)
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_19\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"1234-12-23T12:34:56Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -147,7 +153,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_trim)
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_trim\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"1234-12-23T12:34:56.78901Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -171,7 +177,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_full)
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_full\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"1234-12-23T12:34:56.7890123Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -202,7 +208,7 @@ TEST_F(ConvertC2SQL_Timestamp, Timestamp2Timestamp_decdigits_7)
 		"{\"query\": \"Timestamp2Timestamp_decdigits_7\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"2345-01-23T12:34:56.7890123Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -234,7 +240,7 @@ TEST_F(ConvertC2SQL_Timestamp, Binary2Timestamp_colsize_0)
 		"{\"query\": \"Binary2Timestamp_colsize_0\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"2345-01-23T12:34:56.789Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -262,7 +268,7 @@ TEST_F(ConvertC2SQL_Timestamp, Date2Timestamp)
 		"{\"query\": \"Date2Timestamp\", "
 		"\"params\": [{\"type\": \"DATE\", "
 		"\"value\": \"2345-01-23T00:00:00.000Z\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }

--- a/test/test_conversion_c2sql_varchar.cc
+++ b/test/test_conversion_c2sql_varchar.cc
@@ -9,6 +9,12 @@
 
 #include <string.h>
 
+#ifdef _WIN64
+#	define CLIENT_ID	"\"client_id\": \"odbc64\""
+#else /* _WIN64 */
+#	define CLIENT_ID	"\"client_id\": \"odbc32\""
+#endif /* _WIN64 */
+
 
 namespace test {
 
@@ -34,7 +40,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_empty)
 		"{\"query\": \"CStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -58,7 +64,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_empty)
 		"{\"query\": \"WStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -82,7 +88,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi)
 		"{\"query\": \"WStr2Varchar_ansi\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"0123abcABC\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -106,7 +112,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar)
 		"{\"query\": \"CStr2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"0123abcABC\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -130,7 +136,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi_jsonescape)
 		"{\"query\": \"WStr2Varchar_ansi_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -154,7 +160,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape)
 		"{\"query\": \"CStr2Varchar_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -178,7 +184,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_jsonescape)
 		"{\"query\": \"WStr2Varchar_u8_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -202,7 +208,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape)
 		"{\"query\": \"WStr2Varchar_u8_fullescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -224,7 +230,7 @@ TEST_F(ConvertC2SQL_Varchar, Short2Varchar)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", \"value\": \"-12345\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -247,7 +253,7 @@ TEST_F(ConvertC2SQL_Varchar, Bigint2Varchar)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bigint2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"9223372036854775807\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }
@@ -287,7 +293,7 @@ TEST_F(ConvertC2SQL_Varchar, Double2Varchar)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"1.2000e+00\"}], "
-		"\"mode\": \"ODBC\"}");
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
 }


### PR DESCRIPTION
Currently, in ODBC mode, ES/SQL returns a millis timestamp for "date"
type. This can be negative for datetimes before the Epoch. There's no
standard Win C library function that will work with negative Unix
timestamps, so this commit disables the ODBC for non-catalog statements,
promting ES/SQL to send the "date" as an ISO8601 string.

Additionally add a "client_id" request parameter, to take "odbc32" or
"odbc64" values, depending on the driver build.