### PR TITLE
Fix: parameter length handling, error reporting, timestamp handling

### DIFF
--- a/driver/catalogue.c
+++ b/driver/catalogue.c
@@ -123,7 +123,7 @@ SQLSMALLINT copy_current_catalog(esodbc_dbc_st *dbc, SQLWCHAR *dest,
 	assert(stmt);
 
 	if (! SQL_SUCCEEDED(attach_sql(stmt, MK_WPTR(SYS_CATALOGS),
-				sizeof(SYS_CATALOGS) - 1, /*is catalog*/TRUE))) {
+				sizeof(SYS_CATALOGS) - 1))) {
 		ERRH(dbc, "failed to attach query to statement.");
 		goto end;
 	}
@@ -403,7 +403,7 @@ SQLRETURN EsSQLTablesW(
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuf, pos, /*is_catalog*/TRUE);
+	ret = attach_sql(stmt, wbuf, pos);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}
@@ -539,7 +539,7 @@ SQLRETURN EsSQLColumnsW
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuf, pos, /*is_catalog*/TRUE);
+	ret = attach_sql(stmt, wbuf, pos);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1162,7 +1162,7 @@ static SQLRETURN check_server_version(esodbc_dbc_st *dbc)
 	const wchar_t *tl_key[] = {L"version"}; /* top-level key of interest */
 	const wchar_t *version_key[] = {L"number"};
 	wstr_st ver_no;
-	wstr_st own_ver = WSTR_INIT(STR(DRV_VERSION)); /*build-type define*/
+	wstr_st own_ver = WSTR_INIT(STR(DRV_VERSION)); /*build-time define*/
 #	ifndef NDEBUG
 	SQLWCHAR *pos, *end;
 #	endif /* !NDEBUG */

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -20,7 +20,8 @@
 /* HTTP headers default for every request */
 #define HTTP_ACCEPT_JSON		"Accept: application/json"
 #define HTTP_CONTENT_TYPE_JSON	"Content-Type: application/json; charset=utf-8"
-#define HTTP_TEST_JSON			"{\"query\": \"SELECT 0\"}"
+#define HTTP_TEST_JSON			\
+	"{\"query\": \"SELECT 0\"" JSON_KEY_VAL_MODE JSON_KEY_CLT_ID "}"
 
 /* Elasticsearch/SQL data types */
 /* 2 */

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -736,7 +736,7 @@ SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body)
 		/* copy any error occured at DBC level back down to the statement,
 		 * where it's going to be read from. */
 		if (HDRH(dbc)->diag.state) {
-			stmt->hdr.diag = dbc->hdr.diag;
+			HDRH(stmt)->diag = HDRH(dbc)->diag;
 		}
 	}
 

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -707,6 +707,7 @@ SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body)
 	tout = dbc->timeout < stmt->query_timeout ? stmt->query_timeout :
 		dbc->timeout;
 
+	HDRH(dbc)->diag.state = SQL_STATE_00000;
 	code = -1; /* init value */
 	if (dbc_curl_add_post_body(dbc, tout, u8body) &&
 		dbc_curl_perform(dbc, &code, &resp)) {
@@ -731,6 +732,12 @@ SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body)
 	/* was there an error answer received correctly? */
 	if (0 < code) {
 		ret = attach_error(stmt, &resp, code);
+	} else {
+		/* copy any error occured at DBC level back down to the statement,
+		 * where it's going to be read from. */
+		if (HDRH(dbc)->diag.state) {
+			stmt->hdr.diag = dbc->hdr.diag;
+		}
 	}
 
 	/* an answer might have been received, but a late curl error (like
@@ -740,9 +747,6 @@ SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body)
 		resp.str = NULL;
 	}
 end:
-	/* copy any error occured at DBC level back down to the statement, where
-	 * it's going to be read from. */
-	stmt->hdr.diag = dbc->hdr.diag;
 	return ret;
 }
 
@@ -1157,7 +1161,7 @@ static SQLRETURN check_server_version(esodbc_dbc_st *dbc)
 	cstr_st resp = {0};
 	SQLRETURN ret;
 	UJObject obj, o_version, o_number;
-	void *state;
+	void *state = NULL;
 	int unpacked;
 	const wchar_t *tl_key[] = {L"version"}; /* top-level key of interest */
 	const wchar_t *version_key[] = {L"number"};
@@ -1179,18 +1183,22 @@ static SQLRETURN check_server_version(esodbc_dbc_st *dbc)
 		return ret;
 	}
 
+	HDRH(dbc)->diag.state = SQL_STATE_00000;
 	if (! dbc_curl_perform(dbc, &code, &resp)) {
 		dbc_curl_post_diag(dbc, SQL_STATE_HY000);
 		cleanup_curl(dbc);
 		return SQL_ERROR;
 	}
-	if ((code != 200) || (! resp.cnt)) {
-		ERRH(dbc, "failed to get a positive response with body: code=%ld, "
+	if (! resp.cnt) {
+		ERRH(dbc, "failed to get a response with body: code=%ld, "
 				"body len: %zu.", code, resp.cnt);
 		goto err;
+	} else if (code != 200) {
+		ret = attach_error(dbc, &resp, code);
+		goto err;
 	}
+	/* 200 with body received: decode (hopefully JSON) answer */
 
-	state = NULL;
 	obj = UJDecode(resp.str, resp.cnt, /*heap f()s*/NULL, &state);
 	if (! obj) {
 		ERRH(dbc, "failed to parse as JSON");
@@ -1254,7 +1262,12 @@ err:
 	if (state) {
 		UJFree(state);
 	}
-	RET_HDIAG(dbc, SQL_STATE_08S01, "Failed to extract server's version", 0);
+	if (HDRH(dbc)->diag.state) {
+		RET_STATE(HDRH(dbc)->diag.state);
+	} else {
+		RET_HDIAG(dbc, SQL_STATE_08S01,
+				"Failed to extract server's version", 0);
+	}
 }
 
 /* fully initializes a DBC and performs a simple test query */
@@ -2031,6 +2044,11 @@ static BOOL load_es_types(esodbc_dbc_st *dbc)
 #endif /* TESTING */
 		if (! SQL_SUCCEEDED(EsSQLGetTypeInfoW(stmt, SQL_ALL_TYPES))) {
 			ERRH(stmt, "failed to query Elasticsearch.");
+			/* if there's a message received from ES (which ends up attached
+			 * to the statement), copy it on the DBC */
+			if (HDRH(stmt)->diag.state) {
+				HDRH(dbc)->diag = HDRH(stmt)->diag;
+			}
 			goto end;
 		}
 	}
@@ -2356,10 +2374,18 @@ SQLRETURN EsSQLDriverConnectW
 			RET_HDIAGS(dbc, SQL_STATE_HY110);
 	}
 
+	HDRH(dbc)->diag.state = SQL_STATE_00000;
 	if (! load_es_types(dbc)) {
 		ERRH(dbc, "failed to load Elasticsearch/SQL types.");
-		RET_HDIAG(dbc, SQL_STATE_HY000,
-			"failed to load Elasticsearch/SQL types", 0);
+		TRACE;
+		if (HDRH(dbc)->diag.state) {
+			TRACE;
+			RET_STATE(HDRH(dbc)->diag.state);
+		} else {
+			TRACE;
+			RET_HDIAG(dbc, SQL_STATE_HY000,
+				"failed to load Elasticsearch/SQL types", 0);
+		}
 	}
 
 	/* save the original DSN and (new) server name for later inquiry by app */

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -2607,17 +2607,14 @@ SQLRETURN EsSQLSetDescFieldW(
 		/* <SQLLEN> */
 		/* R/O fields: display_size */
 		case SQL_DESC_OCTET_LENGTH:
-			DBGH(desc, "setting octet length: %ld.",
-					(SQLLEN)(intptr_t)ValuePtr);
-			/* rec field's type is signed :/; a negative is dangerous l8r  */
 			slen = (SQLLEN)(intptr_t)ValuePtr;
-			if (slen < 0 && slen != SQL_NTSL) {
-				ERRH(desc, "octet length attribute can't be negative (%lld)",
-						slen);
-				RET_HDIAG(desc, SQL_STATE_HY000,
-						"invalid negative octet lenght attribute", 0);
+			DBGH(desc, "setting octet length: %ld.", slen);
+			/* rec field's type is signed; a negative can be dangerous */
+			if (slen < 0) {
+				WARNH(desc, "negative octet length provided (%lld)", slen);
+				/* no eror returned: in non-str/binary, it is to be ignorred */
 			}
-			rec->octet_length = (SQLLEN)(intptr_t)ValuePtr;
+			rec->octet_length = slen;
 			break;
 
 		/* <SQLULEN> */

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -302,7 +302,6 @@ typedef struct struct_stmt {
 
 	/* cache UTF8 JSON serialized SQL: can be (re)used with varying params */
 	cstr_st u8sql;
-	BOOL is_catalog; /* statment is for a catalog query */
 
 	/* pointers to the current descriptors */
 	esodbc_desc_st *ard;

--- a/driver/info.c
+++ b/driver/info.c
@@ -1208,7 +1208,7 @@ SQLRETURN EsSQLGetTypeInfoW(SQLHSTMT StatementHandle, SQLSMALLINT DataType)
 
 	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
 	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuff, cnt, /*is_catalog*/TRUE);
+	ret = attach_sql(stmt, wbuff, cnt);
 	if (SQL_SUCCEEDED(ret)) {
 		ret = EsSQLExecute(stmt);
 	}

--- a/driver/log.c
+++ b/driver/log.c
@@ -148,6 +148,8 @@ BOOL filelog_print_path(wstr_st *dest, wstr_st *dir_path, wstr_st *ident)
 	}
 
 	/* build the log full path name */
+	/* swprintf fails if formatted string would overrun the buffer, while
+	 * _snwprintf doesn't (though also not portable) */
 	cnt = _snwprintf(dest->str, dest->cnt,
 			L"%.*s" "%c" "%s" "_%d%.2d%.2d%.2d%.2d%.2d_" "%.*s" "%s",
 			(int)dir.cnt, dir.str,

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -452,7 +452,7 @@ SQLRETURN TEST_API attach_error(SQLHANDLE hnd, cstr_st *body, int code)
 	char buff[SQL_MAX_MESSAGE_LENGTH];
 	size_t to_copy;
 
-	ERRH(hnd, "POST failure %d body: len: %zu, content: `%.*s`.", code,
+	ERRH(hnd, "request failure %d body: len: %zu, content: `%.*s`.", code,
 		body->cnt, LCSTR(body));
 
 	if (body->cnt) {

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1830,21 +1830,6 @@ static SQLRETURN serialize_params(esodbc_stmt_st *stmt, char *dest,
  */
 SQLRETURN TEST_API serialize_statement(esodbc_stmt_st *stmt, cstr_st *buff)
 {
-	/* JSON body build elements */
-#	define JSON_KEY_QUERY		"\"query\": " /* will always be the 1st key */
-#	define JSON_KEY_CURSOR		"\"cursor\": " /* 1st key */
-#	define JSON_KEY_PARAMS		", \"params\": " /* n-th key */
-#	define JSON_KEY_FETCH		", \"fetch_size\": " /* n-th key */
-#	define JSON_KEY_REQ_TOUT	", \"request_timeout\": " /* n-th key */
-#	define JSON_KEY_PAGE_TOUT	", \"page_timeout\": " /* n-th key */
-#	define JSON_KEY_TIME_ZONE	", \"time_zone\": " /* n-th key */
-#	define JSON_KEY_VAL_MODE	", \"mode\": \"ODBC\"" /* n-th key */
-#	ifdef _WIN64
-#		define JSON_KEY_CLT_ID		", \"client_id\": \"odbc64\"" /* n-th k. */
-#	else /* _WIN64 */
-#		define JSON_KEY_CLT_ID		", \"client_id\": \"odbc32\"" /* n-th k. */
-#	endif /* _WIN64 */
-
 	SQLRETURN ret = SQL_SUCCESS;
 	size_t bodylen, pos, u8len, len;
 	char *body;

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -116,5 +116,20 @@ SQLRETURN EsSQLNumParams(
 	SQLSMALLINT       *ParameterCountPtr);
 SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 
+	/* JSON body build elements */
+#define JSON_KEY_QUERY			"\"query\": " /* will always be the 1st key */
+#define JSON_KEY_CURSOR			"\"cursor\": " /* 1st key */
+#define JSON_KEY_PARAMS			", \"params\": " /* n-th key */
+#define JSON_KEY_FETCH			", \"fetch_size\": " /* n-th key */
+#define JSON_KEY_REQ_TOUT		", \"request_timeout\": " /* n-th key */
+#define JSON_KEY_PAGE_TOUT		", \"page_timeout\": " /* n-th key */
+#define JSON_KEY_TIME_ZONE		", \"time_zone\": " /* n-th key */
+#define JSON_KEY_VAL_MODE		", \"mode\": \"ODBC\"" /* n-th key */
+#ifdef _WIN64
+#	define JSON_KEY_CLT_ID		", \"client_id\": \"odbc64\"" /* n-th k. */
+#else /* _WIN64 */
+#	define JSON_KEY_CLT_ID		", \"client_id\": \"odbc32\"" /* n-th k. */
+#endif /* _WIN64 */
+
 
 #endif /* __QUERIES_H__ */

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -14,7 +14,7 @@ SQLRETURN TEST_API attach_answer(esodbc_stmt_st *stmt, char *buff,
 	size_t blen);
 SQLRETURN TEST_API attach_error(SQLHANDLE hnd, cstr_st *body, int code);
 SQLRETURN TEST_API attach_sql(esodbc_stmt_st *stmt, const SQLWCHAR *sql,
-	size_t tlen, BOOL is_catalog);
+	size_t tlen);
 void detach_sql(esodbc_stmt_st *stmt);
 SQLRETURN TEST_API serialize_statement(esodbc_stmt_st *stmt, cstr_st *buff);
 

--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -27,9 +27,7 @@ extern "C" {
 
 /* convenience casting macros */
 #define ATTACH_ANSWER(_h, _s, _l)   attach_answer((esodbc_stmt_st *)_h, _s, _l)
-#define ATTACH_SQL(_h, _s, _l)      \
-	/* is_catalog set to TRUE, since all tests expect the mode param */ \
-	attach_sql((esodbc_stmt_st *)_h, _s, _l, TRUE)
+#define ATTACH_SQL(_h, _s, _l)      attach_sql((esodbc_stmt_st *)_h, _s, _l)
 
 #define ASSERT_CSTREQ(_c1, _c2) \
 	do { \

--- a/test/test_conversion_c2sql_boolean.cc
+++ b/test/test_conversion_c2sql_boolean.cc
@@ -26,9 +26,10 @@ TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
   prepareStatement();
 
 	SQLCHAR val[] = "1";
+	SQLLEN osize = SQL_NTSL;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-			ESODBC_SQL_BOOLEAN, /*size*/0, /*decdigits*/0, val, sizeof(val),
-			/*IndLen*/NULL);
+			ESODBC_SQL_BOOLEAN, /*size*/0, /*decdigits*/0, val,
+			sizeof(val) - /*\0*/1, &osize);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st buff = {NULL, 0};
@@ -46,10 +47,10 @@ TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 {
   prepareStatement();
 
-	SQLWCHAR val[] = L"0";
+	SQLWCHAR val[] = L"0X";
+	SQLLEN osize = sizeof(val[0]);
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-			ESODBC_SQL_BOOLEAN, /*size*/0, /*decdigits*/0, val, sizeof(val),
-			/*IndLen*/NULL);
+			ESODBC_SQL_BOOLEAN, /*size*/0, /*decdigits*/0, val, 0, &osize);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st buff = {NULL, 0};

--- a/test/test_conversion_c2sql_interval.cc
+++ b/test/test_conversion_c2sql_interval.cc
@@ -277,6 +277,34 @@ TEST_F(ConvertC2SQL_Interval, Interval2Interval_year_to_month)
 	ASSERT_CSTREQ(buff, expect);
 }
 
+TEST_F(ConvertC2SQL_Interval, Interval_binary2Interval_year_to_month)
+{
+	prepareStatement();
+
+	SQL_INTERVAL_STRUCT val;
+	val.interval_type = SQL_IS_YEAR_TO_MONTH;
+	val.interval_sign = SQL_TRUE;
+	val.intval.year_month.year = 12;
+	val.intval.year_month.month = 11;
+
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT,
+			SQL_C_BINARY, SQL_INTERVAL_YEAR_TO_MONTH,
+			/*size*/2, /*decdigits*/3, &val, sizeof(val), /*IndLen*/NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	cstr_st buff = {NULL, 0};
+	ret = serialize_statement((esodbc_stmt_st *)stmt, &buff);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	cstr_st expect = CSTR_INIT(
+		"{\"query\": \"Interval_binary2Interval_year_to_month\", "
+		"\"params\": [{\"type\": \"INTERVAL_YEAR_TO_MONTH\", "
+		"\"value\": \"P-12Y-11M\"}], "
+		"\"mode\": \"ODBC\", " CLIENT_ID "}");
+
+	ASSERT_CSTREQ(buff, expect);
+}
+
 
 
 } // test namespace

--- a/test/test_conversion_c2sql_interval.cc
+++ b/test/test_conversion_c2sql_interval.cc
@@ -176,7 +176,7 @@ TEST_F(ConvertC2SQL_Interval, SBigInt2Interval_second_all_0)
 	ASSERT_CSTREQ(buff, expect);
 }
 
-TEST_F(ConvertC2SQL_Interval, WChar2Interval_day_to_second)
+TEST_F(ConvertC2SQL_Interval, WStr2Interval_day_to_second)
 {
 	prepareStatement();
 
@@ -191,7 +191,7 @@ TEST_F(ConvertC2SQL_Interval, WChar2Interval_day_to_second)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT(
-		"{\"query\": \"WChar2Interval_day_to_second\", "
+		"{\"query\": \"WStr2Interval_day_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_DAY_TO_SECOND\", "
 		"\"value\": \"P-2DT-3H-4M-5.678S\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
@@ -199,7 +199,7 @@ TEST_F(ConvertC2SQL_Interval, WChar2Interval_day_to_second)
 	ASSERT_CSTREQ(buff, expect);
 }
 
-TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second)
+TEST_F(ConvertC2SQL_Interval, CStr2Interval_hour_to_second)
 {
 	prepareStatement();
 
@@ -214,7 +214,7 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT(
-		"{\"query\": \"Char2Interval_hour_to_second\", "
+		"{\"query\": \"CStr2Interval_hour_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
@@ -222,7 +222,7 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second)
 	ASSERT_CSTREQ(buff, expect);
 }
 
-TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second_force_alloc)
+TEST_F(ConvertC2SQL_Interval, CStr2Interval_hour_to_second_force_alloc)
 {
 	prepareStatement();
 
@@ -231,9 +231,10 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second_force_alloc)
 		"                                                           "
 		"                                                           "
 		"SECOND";
+	SQLLEN osize = sizeof(val) - 1;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
 			SQL_INTERVAL_HOUR_TO_SECOND, /*size*/2, /*decdigits*/3, val,
-			sizeof(val) - 1, /*IndLen*/NULL);
+			0, &osize);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st buff = {NULL, 0};
@@ -241,7 +242,7 @@ TEST_F(ConvertC2SQL_Interval, Char2Interval_hour_to_second_force_alloc)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	cstr_st expect = CSTR_INIT(
-		"{\"query\": \"Char2Interval_hour_to_second_force_alloc\", "
+		"{\"query\": \"CStr2Interval_hour_to_second_force_alloc\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");

--- a/test/test_conversion_c2sql_numeric.cc
+++ b/test/test_conversion_c2sql_numeric.cc
@@ -28,7 +28,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Short2Integer)
 
 	SQLCHAR val[] = "-12345";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, SQL_NTSL,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -65,7 +65,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Short2Integer_fail_22018)
 
 	SQLCHAR val[] = "-12345.123X"; // NaN
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, sizeof(val) - /*\0*/1,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -82,7 +82,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_LLong2Long)
 
 	SQLCHAR val[] = "9223372036854775807"; /* LLONG_MAX */
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-			SQL_BIGINT, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_BIGINT, /*size*/0, /*decdigits*/0, val, SQL_NTSL,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -122,7 +122,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Float2Long)
 
 	SQLCHAR val[] = "9223372036854775806.12345"; /* LLONG_MAX.12345 - 1 */
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-			SQL_BIGINT, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_BIGINT, /*size*/0, /*decdigits*/0, val, sizeof(val) - /*\0*/1,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -145,7 +145,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Byte2Integer)
 
 	SQLWCHAR val[] = L"-128";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_INTEGER, /*size*/0, /*decdigits*/0, val, SQL_NTSL,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -167,7 +167,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2HFloat)
 
 	SQLWCHAR val[] = L"-12345678901234567890.123456789";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-			SQL_FLOAT, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			SQL_FLOAT, /*size*/0, /*decdigits*/0, val, SQL_NTSL,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
@@ -190,7 +190,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2SFloat)
 
 	SQLWCHAR val[] = L"-12345678901234567890.123456789";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-			SQL_FLOAT, /*size*/17, /*decdigits*/0, val, sizeof(val),
+			SQL_FLOAT, /*size*/17, /*decdigits*/0, val, sizeof(val) - /*\0*/2,
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 


### PR DESCRIPTION
This PR fixes the the parameter length handling for strings, when these are converted to
- a number: the driver no longer (incorrectly) expects the string to be 0-terminated (and thus trim the last character);
- an interval: the length of the string is read from a corrected descriptor field.

The binary to interval conversion is now enabled.
The workaround for timestamps, which are now serialized again as ISO8601 string is reverted.

The PR also fixes overwriting of the error message received from the server (with an internal failure message) and adds the (so far missing) ODBC mode to the request JSON object used for connection testing, to have Elasticsearch return an error in case of missing appropriate license.
