### PR TITLE
Provide specific err msg if DSN name is invalid

### DIFF
--- a/dsneditor/EsOdbcDsnBinding/EsOdbcDsnBinding.h
+++ b/dsneditor/EsOdbcDsnBinding/EsOdbcDsnBinding.h
@@ -13,7 +13,7 @@
  * is desired by user. */
 #define ESODBC_DSN_OVERWRITE_FLAG				(1<<0)
 
-#define ESODBC_DSN_NO_ERROR							0
+#define ESODBC_DSN_NO_ERROR						0
 /* Code returned by callback to signal that given DSN name already exists. */
 #define ESODBC_DSN_EXISTS_ERROR					-1
 /* The receivd DSN string (connection/00-list) is NULL. */
@@ -21,7 +21,7 @@
 /* The receivd DSN string couldn't be parsed. */
 #define ESODBC_DSN_INVALID_ERROR				-3
 /* The receivd DSN name is invalid. */
-#define ESODBC_DSN_NAME_INVALID_ERROR		-4
+#define ESODBC_DSN_NAME_INVALID_ERROR			-4
 /* Non charachteristic (system?) error. */
 #define ESODBC_DSN_GENERIC_ERROR				-127
 

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -23,6 +23,7 @@ namespace EsOdbcDsnEditor
 	public partial class DsnEditorForm : Form
 	{
 		private const int ESODBC_DSN_EXISTS_ERROR = -1;
+		private const int ESODBC_DSN_NAME_INVALID_ERROR = -4;
 
 		private DriverCallbackDelegate testConnection;
 		private DriverCallbackDelegate saveDsn;
@@ -186,7 +187,9 @@ namespace EsOdbcDsnEditor
 			}
 
 			if (errorMessage.Length <= 0) {
-				errorMessage = "Saving the DSN failed";
+				errorMessage = (result == ESODBC_DSN_NAME_INVALID_ERROR)
+					? "Invalid DSN name"
+					: "Invalid DSN name";
 			}
 
 			MessageBox.Show(errorMessage, "Operation failure", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -189,7 +189,7 @@ namespace EsOdbcDsnEditor
 			if (errorMessage.Length <= 0) {
 				errorMessage = (result == ESODBC_DSN_NAME_INVALID_ERROR)
 					? "Invalid DSN name"
-					: "Invalid DSN name";
+					: "Saving the DSN failed";
 			}
 
 			MessageBox.Show(errorMessage, "Operation failure", MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
If the user provides an invalid DSN name (validation by ODBC lib fails),
the driver returns a specific error code. Use this code to return the
user the reason why saving a DSN can't take place.