### PR TITLE
Add version check control parameter

### DIFF
--- a/driver/defs.h
+++ b/driver/defs.h
@@ -164,7 +164,9 @@
 #define ESODBC_DEF_TRACE_ENABLED	"0"
 /* default tracing level */
 #define ESODBC_DEF_TRACE_LEVEL		"WARN"
-#define ESODBC_PWD_VAL_SUBST		"<original substituted>"
+#define ESODBC_PWD_VAL_SUBST		"<redacted>"
+/* default version checking mode: strict, major, none (dbg only) */
+#define ESODBC_DEF_VERSION_CHECKING	ESODBC_DSN_VC_STRICT
 
 /*
  *

--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -77,6 +77,7 @@ int assign_dsn_attr(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_PACKING), &attrs->packing},
 		{&MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE), &attrs->max_fetch_size},
 		{&MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB), &attrs->max_body_size},
+		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -404,6 +405,7 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_PACKING), &attrs->packing},
 		{&MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE), &attrs->max_fetch_size},
 		{&MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB), &attrs->max_body_size},
+		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -674,6 +676,11 @@ BOOL write_system_dsn(esodbc_dsn_attrs_st *new_attrs,
 			old_attrs ? &old_attrs->max_body_size : NULL
 		},
 		{
+			&MK_WSTR(ESODBC_DSN_VERSION_CHECKING),
+			&new_attrs->version_checking,
+			old_attrs ? &old_attrs->version_checking : NULL
+		},
+		{
 			&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &new_attrs->trace_enabled,
 			old_attrs ? &old_attrs->trace_enabled : NULL
 		},
@@ -757,6 +764,7 @@ long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 		{&attrs->packing, &MK_WSTR(ESODBC_DSN_PACKING)},
 		{&attrs->max_fetch_size, &MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE)},
 		{&attrs->max_body_size, &MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB)},
+		{&attrs->version_checking, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING)},
 		{&attrs->trace_enabled, &MK_WSTR(ESODBC_DSN_TRACE_ENABLED)},
 		{&attrs->trace_file, &MK_WSTR(ESODBC_DSN_TRACE_FILE)},
 		{&attrs->trace_level, &MK_WSTR(ESODBC_DSN_TRACE_LEVEL)},
@@ -834,6 +842,9 @@ void assign_dsn_defaults(esodbc_dsn_attrs_st *attrs)
 			/*overwrite?*/FALSE);
 	res |= assign_dsn_attr(attrs, &MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB),
 			&MK_WSTR(ESODBC_DEF_MAX_BODY_SIZE_MB),
+			/*overwrite?*/FALSE);
+	res |= assign_dsn_attr(attrs, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING),
+			&MK_WSTR(ESODBC_DEF_VERSION_CHECKING),
 			/*overwrite?*/FALSE);
 
 	/* default: no trace file */

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -32,9 +32,18 @@
 #define ESODBC_DSN_PACKING			"Packing"
 #define ESODBC_DSN_MAX_FETCH_SIZE	"MaxFetchSize"
 #define ESODBC_DSN_MAX_BODY_SIZE_MB	"MaxBodySizeMB"
+#define ESODBC_DSN_VERSION_CHECKING	"VersionChecking"
 #define ESODBC_DSN_TRACE_ENABLED	"TraceEnabled"
 #define ESODBC_DSN_TRACE_FILE		"TraceFile"
 #define ESODBC_DSN_TRACE_LEVEL		"TraceLevel"
+
+/* Packing values */
+#define ESODBC_DSN_PACK_JSON		"JSON"
+#define ESODBC_DSN_PACK_CBOR		"CBOR"
+/* VersionChecking values */
+#define ESODBC_DSN_VC_STRICT		"strict"
+#define ESODBC_DSN_VC_MAJOR			"major"
+#define ESODBC_DSN_VC_NONE			"none"
 
 /* stucture to collect all attributes in a connection string */
 typedef struct {
@@ -55,10 +64,11 @@ typedef struct {
 	wstr_st packing;
 	wstr_st max_fetch_size;
 	wstr_st max_body_size;
+	wstr_st version_checking;
 	wstr_st trace_enabled;
 	wstr_st trace_file;
 	wstr_st trace_level;
-#define ESODBC_DSN_ATTRS_COUNT	20
+#define ESODBC_DSN_ATTRS_COUNT	21
 	SQLWCHAR buff[ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN];
 } esodbc_dsn_attrs_st;
 

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -130,6 +130,10 @@ typedef struct struct_dbc {
 
 	wstr_st dsn; /* data source name SQLGetInfo(SQL_DATA_SOURCE_NAME) */
 	wstr_st server; /* ~ name; requested with SQLGetInfo(SQL_SERVER_NAME) */
+	union {
+		wstr_st string; /* version: SQLGetInfo(SQL_DBMS_VER)  */
+		unsigned char checking; /* first letter of DSN config option */
+	} srv_ver; /* server version */
 	cstr_st url; /* SQL URL (posts) */
 	cstr_st root_url; /* root URL (gets) */
 	enum {

--- a/driver/info.c
+++ b/driver/info.c
@@ -304,8 +304,9 @@ static SQLRETURN getinfo_dbms_product(
 					&MK_WSTR(ESODBC_ELASTICSEARCH_NAME), BufferLength,
 					StringLengthPtr);
 		case SQL_DBMS_VER:
-			DBGH(dbc, "requested: DBMS version (`%s`).", STR(DRV_VERSION));
-			return write_wstr(dbc, InfoValue, &MK_WSTR(STR(DRV_VERSION)),
+			DBGH(dbc, "requested: DBMS version (`" LWPDL "`).",
+					LWSTR(&dbc->srv_ver.string));
+			return write_wstr(dbc, InfoValue, &dbc->srv_ver.string,
 					BufferLength, StringLengthPtr);
 	}
 	*handled = FALSE;

--- a/driver/util.c
+++ b/driver/util.c
@@ -287,6 +287,18 @@ void trim_ws(cstr_st *cstr)
 	};
 }
 
+BOOL wtrim_at(wstr_st *wstr, SQLWCHAR wchar)
+{
+	SQLWCHAR *pos, *end;
+
+	for (pos = wstr->str, end = pos + wstr->cnt; pos < end; pos ++) {
+		if (*pos == wchar) {
+			wstr->cnt = pos - wstr->str;
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
 
 /*
  * Converts a wchar_t string to a C string for ASCII characters.
@@ -398,7 +410,8 @@ static inline size_t json_escaped_len(const char *json, size_t len)
 		switch(uchar) {
 			case '"':
 			case '\\':
-			case '/':
+			/* '/' needs no quoting as per ECMA spec, even if listed on
+			 * json.org; ES/SQL uses it unescaped in cursor values. */
 			case '\b':
 			case '\f':
 			case '\n':
@@ -449,7 +462,8 @@ size_t json_escape(const char *jin, size_t inlen, char *jout, size_t outlen)
 			} while (0);
 			case '"':
 			case '\\':
-			case '/':
+			/* '/' needs no quoting as per ECMA spec, even if listed on
+			 * json.org; ES/SQL uses it unescaped in cursor values. */
 				if (outlen <= pos + 1) {
 					i = inlen; // break the for loop
 					continue;

--- a/driver/util.h
+++ b/driver/util.h
@@ -153,7 +153,9 @@ void trim_ws(cstr_st *str);
 void wltrim_ws(wstr_st *wstr);
 void wrtrim_ws(wstr_st *wstr);
 #define wtrim_ws(_w) do { wltrim_ws(_w); wrtrim_ws(_w); } while (0)
-
+/* Trim the w-string at first encounter of the give w-char.
+ * Returns TRUE if character has been encounter / trimming occured. */
+BOOL wtrim_at(wstr_st *wstr, SQLWCHAR wchar);
 
 BOOL wstr2bool(wstr_st *val);
 /* Converts a [cw]str_st to a SQL(U)BIGINT.


### PR DESCRIPTION
A new parameter 'VersionChecking' is added, to control how strict the
version check is performed:
- strict: the default; will only connect to a server with same version;
- major: major versions must match;
- none: only avail in debug builds; no version check.

The commit also fixes a memory leak: the body of the GET (containing the
server version) is now freed.