### PR TITLE
Change type name from DATE to DATETIME

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1504,7 +1504,7 @@ static BOOL elastic_intervals_name2types(wstr_st *type_name,
 
 /* Maps ES/SQL type name to C SQL and SQL id values.
  * ES/SQL type ID uses ODBC spec 3.x values for most common types (ES/SQL's
- * "DATE" is an ODBC "TIMESTAMP", as an exception).
+ * "DATETIME" is an ODBC "TIMESTAMP", as an exception).
  * The values are set here, since the driver:
  * - must set these for the non-common types (KEYWORD etc.);
  * - would need to check if the above mentioned identity is still true.

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -30,7 +30,6 @@
 #define TYPE_BYTE			"BYTE"
 #define TYPE_LONG			"LONG"
 #define TYPE_TEXT			"TEXT"
-#define TYPE_DATE			"DATE"
 #define TYPE_NULL			"NULL"
 /* 5 */
 #define TYPE_SHORT			"SHORT"
@@ -44,6 +43,8 @@
 #define TYPE_BOOLEAN		"BOOLEAN"
 #define TYPE_INTEGER		"INTEGER"
 #define TYPE_KEYWORD		"KEYWORD"
+/* 8 */
+#define TYPE_DATETIME		"DATETIME"
 /* 10 */
 #define TYPE_HALF_FLOAT		"HALF_FLOAT"
 /* 11 */
@@ -116,8 +117,8 @@
 #define ES_IP_TO_CSQL			SQL_C_WCHAR /* XXX: CBOR needs _CHAR */
 #define ES_IP_TO_SQL			SQL_VARCHAR
 /* 93: SQL_TYPE_TIMESTAMP -> SQL_C_TYPE_TIMESTAMP */
-#define ES_DATE_TO_CSQL			SQL_C_TYPE_TIMESTAMP
-#define ES_DATE_TO_SQL			SQL_TYPE_TIMESTAMP
+#define ES_DATETIME_TO_CSQL		SQL_C_TYPE_TIMESTAMP
+#define ES_DATETIME_TO_SQL		SQL_TYPE_TIMESTAMP
 /* -3: SQL_VARBINARY -> SQL_C_BINARY */
 #define ES_BINARY_TO_CSQL		SQL_C_BINARY
 #define ES_BINARY_TO_SQL		SQL_VARBINARY
@@ -1551,14 +1552,6 @@ static BOOL elastic_name2types(wstr_st *type_name,
 						return TRUE;
 					}
 					break;
-				case (SQLWCHAR)'d':
-					if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_DATE),
-							type_name->cnt)) {
-						*c_sql = ES_DATE_TO_CSQL;
-						*sql = ES_DATE_TO_SQL;
-						return TRUE;
-					}
-					break;
 				case (SQLWCHAR)'n':
 					if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_NULL),
 							type_name->cnt)) {
@@ -1657,6 +1650,16 @@ static BOOL elastic_name2types(wstr_st *type_name,
 						return TRUE;
 					}
 					break;
+			}
+			break;
+
+		/* 8: DATETIME */
+		case sizeof(TYPE_DATETIME) - 1:
+			if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_DATETIME),
+					type_name->cnt)) {
+				*c_sql = ES_DATETIME_TO_CSQL;
+				*sql = ES_DATETIME_TO_SQL;
+				return TRUE;
 			}
 			break;
 

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -69,7 +69,7 @@ static const char systypes_answer[] = "\
 			false, false, null, null, null, 12, 0, null, null],\
 		[\"BOOLEAN\", 16, 1, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, null, null, 16, 0, null, null],\
-		[\"DATE\", 93, 24, \"'\", \"'\", null, 2, false, 3, true, false,\
+		[\"DATETIME\", 93, 24, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, 3, 3, 9, 3, null, null],\
 		[\"INTERVAL_YEAR\", 101, 7, \"'\", \"'\", null, 2, false, 3, true,\
 			false, false, null, null, null, 101, 0, null, null],\

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -87,7 +87,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_16)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_16\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:00Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -111,7 +111,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_19)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_19\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -151,7 +151,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_trim)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_trim\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.78901Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -175,7 +175,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_full)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_full\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.7890123Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -206,7 +206,7 @@ TEST_F(ConvertC2SQL_Timestamp, Timestamp2Timestamp_decdigits_7)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Timestamp2Timestamp_decdigits_7\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T12:34:56.7890123Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -238,7 +238,7 @@ TEST_F(ConvertC2SQL_Timestamp, Binary2Timestamp_colsize_0)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Binary2Timestamp_colsize_0\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T12:34:56.789Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
@@ -266,7 +266,7 @@ TEST_F(ConvertC2SQL_Timestamp, Date2Timestamp)
 
 	cstr_st expect = CSTR_INIT(
 		"{\"query\": \"Date2Timestamp\", "
-		"\"params\": [{\"type\": \"DATE\", "
+		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T00:00:00.000Z\"}], "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 

--- a/test/test_conversion_sql2c_date.cc
+++ b/test/test_conversion_sql2c_date.cc
@@ -36,12 +36,12 @@ TEST_F(ConvertSQL2C_Date, Timestamp2Date) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "2345-01-23T00:00:00Z"
-#define SQL "CAST(" SQL_VAL "AS DATE)"
+#define SQL "CAST(" SQL_VAL "AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\
@@ -64,12 +64,12 @@ TEST_F(ConvertSQL2C_Date, Timestamp2Date_truncate) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "   2345-01-23T12:34:56.789Z  "
-#define SQL "CAST(" SQL_VAL "AS DATE)"
+#define SQL "CAST(" SQL_VAL "AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"CAST(" SQL ")\", \"type\": \"date\"}\
+    {\"name\": \"CAST(" SQL ")\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\

--- a/test/test_conversion_sql2c_time.cc
+++ b/test/test_conversion_sql2c_time.cc
@@ -36,12 +36,12 @@ TEST_F(ConvertSQL2C_Time, Timestamp2Time) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "2345-01-23T12:34:56.000Z"
-#define SQL "CAST(" SQL_VAL "AS DATE)"
+#define SQL "CAST(" SQL_VAL "AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\
@@ -64,12 +64,12 @@ TEST_F(ConvertSQL2C_Time, Timestamp2Time_truncate) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "   2345-01-23T12:34:56.789Z  "
-#define SQL "CAST(" SQL_VAL "AS DATE)"
+#define SQL "CAST(" SQL_VAL "AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\

--- a/test/test_conversion_sql2c_timestamp.cc
+++ b/test/test_conversion_sql2c_timestamp.cc
@@ -36,12 +36,12 @@ TEST_F(ConvertSQL2C_Timestamp, Timestamp2Timestamp_noTruncate) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL   "2345-01-23T12:34:56.789Z"
-#define SQL   "CAST(" SQL_VAL " AS DATE)"
+#define SQL   "CAST(" SQL_VAL " AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\
@@ -69,12 +69,12 @@ TEST_F(ConvertSQL2C_Timestamp, Timestamp2Timestamp_trimming) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "   2345-01-23T12:34:56.789Z  "
-#define SQL   "CAST(" SQL_VAL " AS DATE)"
+#define SQL   "CAST(" SQL_VAL " AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\
@@ -201,12 +201,12 @@ TEST_F(ConvertSQL2C_Timestamp, String2Timestamp_invalidFormat_22018) {
 #undef SQL_VAL
 #undef SQL
 #define SQL_VAL "invalid 2345-01-23T12:34:56.789Z"
-#define SQL   "CAST(" SQL_VAL " AS DATE)"
+#define SQL   "CAST(" SQL_VAL " AS DATETIME)"
 
   const char json_answer[] = "\
 {\
   \"columns\": [\
-    {\"name\": \"" SQL "\", \"type\": \"date\"}\
+    {\"name\": \"" SQL "\", \"type\": \"DATETIME\"}\
   ],\
   \"rows\": [\
     [\"" SQL_VAL "\"]\


### PR DESCRIPTION
ES/SQL renamed the `DATE` type to `DATETIME`, which better conveys the represented data.
This PR applies the same change in the driver.