### PR TITLE
Add SQLEndTran API function

### DIFF
--- a/driver/defs.h
+++ b/driver/defs.h
@@ -126,7 +126,7 @@
 #define ESODBC_DSN_SAMPLE_NAME			"Elasticsearch ODBC Sample DSN"
 
 /* SQL plugin's REST endpoint for SQL */
-#define ELASTIC_SQL_PATH				"/_xpack/sql"
+#define ELASTIC_SQL_PATH				"/_sql"
 
 /* initial receive buffer size for REST answers */
 #define ESODBC_BODY_BUF_START_SIZE		(4 * 1024)

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -1348,7 +1348,13 @@ SQLRETURN  SQL_API SQLCancelHandle(SQLSMALLINT HandleType,
 SQLRETURN  SQL_API SQLEndTran(SQLSMALLINT HandleType, SQLHANDLE Handle,
 	SQLSMALLINT CompletionType)
 {
-	RET_NOT_IMPLEMENTED(Handle);
+	SQLRETURN ret;
+	TRACE3(_IN, Handle, "hph", HandleType, Handle, CompletionType);
+	HND_LOCK(Handle);
+	ret = EsSQLEndTran(HandleType, Handle, CompletionType);
+	HND_UNLOCK(Handle);
+	TRACE4(_IN, Handle, "dhph", ret, HandleType, Handle, CompletionType);
+	return ret;
 }
 
 

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1248,7 +1248,7 @@ SQLRETURN EsSQLCloseCursor(SQLHSTMT StatementHandle)
 		ERRH(stmt, "no open cursor for statement");
 		RET_HDIAGS(stmt, SQL_STATE_24000);
 	}
-	/* TODO: POST /_xpack/sql/close {"cursor":"<cursor>"} if cursor */
+	/* TODO: POST /_sql/close {"cursor":"<cursor>"} if cursor */
 	return EsSQLFreeStmt(StatementHandle, SQL_CLOSE);
 }
 
@@ -1275,6 +1275,17 @@ SQLRETURN EsSQLCancelHandle(SQLSMALLINT HandleType, SQLHANDLE InputHandle)
 {
 	/* see EsSQLCancel() */
 	DBGH(InputHandle, "canceling current handle operation -- NOOP.");
+	return SQL_SUCCESS;
+}
+
+SQLRETURN EsSQLEndTran(SQLSMALLINT HandleType, SQLHANDLE Handle,
+	SQLSMALLINT CompletionType)
+{
+	WARNH(Handle, "transaction ending requested (%hd), despite no "
+			"transactional support advertized", CompletionType);
+	if (CompletionType == SQL_ROLLBACK) {
+		RET_HDIAGS(Handle, SQL_STATE_HYC00);
+	}
 	return SQL_SUCCESS;
 }
 

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -47,6 +47,8 @@ SQLRETURN EsSQLMoreResults(SQLHSTMT hstmt);
 SQLRETURN EsSQLCloseCursor(SQLHSTMT StatementHandle);
 SQLRETURN EsSQLCancel(SQLHSTMT StatementHandle);
 SQLRETURN EsSQLCancelHandle(SQLSMALLINT HandleType, SQLHANDLE InputHandle);
+SQLRETURN EsSQLEndTran(SQLSMALLINT HandleType, SQLHANDLE Handle,
+	SQLSMALLINT CompletionType);
 SQLRETURN EsSQLNumResultCols(SQLHSTMT StatementHandle,
 	_Out_ SQLSMALLINT *ColumnCount);
 


### PR DESCRIPTION
The function is used by some applications (like the pyodbc module for
ODBC wrapping), even though the driver doesn't advertise transaction
support.

It will silently accept commit requests and err on rollbacks.

Also, switch to no XPack SQL REST endpoint.