### PR TITLE
DATE type initial support

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -2397,6 +2397,9 @@ SQLRETURN EsSQLDriverConnectW
 			 * tests (see load_es_types()). */
 			assert(! dbc->hwin);
 			dbc->hwin = hwnd;
+			if (! load_es_types(dbc)) {
+				RET_HDIAGS(dbc, SQL_STATE_HY000);
+			}
 			break;
 #endif /* TESTING */
 

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -28,6 +28,7 @@
 #define TYPE_BYTE			"BYTE"
 #define TYPE_LONG			"LONG"
 #define TYPE_TEXT			"TEXT"
+#define TYPE_DATE			"DATE"
 #define TYPE_NULL			"NULL"
 /* 5 */
 #define TYPE_SHORT			"SHORT"
@@ -114,6 +115,9 @@
 /* 12: SQL_VARCHAR -> SQL_C_WCHAR */
 #define ES_IP_TO_CSQL			SQL_C_WCHAR /* XXX: CBOR needs _CHAR */
 #define ES_IP_TO_SQL			SQL_VARCHAR
+/* 91: SQL_TYPE_DATE -> SQL_C_TYPE_DATE */
+#define ES_DATE_TO_CSQL			SQL_C_TYPE_DATE
+#define ES_DATE_TO_SQL			SQL_TYPE_DATE
 /* 93: SQL_TYPE_TIMESTAMP -> SQL_C_TYPE_TIMESTAMP */
 #define ES_DATETIME_TO_CSQL		SQL_C_TYPE_TIMESTAMP
 #define ES_DATETIME_TO_SQL		SQL_TYPE_TIMESTAMP
@@ -1522,6 +1526,14 @@ static BOOL elastic_name2types(wstr_st *type_name,
 							type_name->cnt)) {
 						*c_sql = ES_TEXT_TO_CSQL;
 						*sql = ES_TEXT_TO_SQL;
+						return TRUE;
+					}
+					break;
+				case (SQLWCHAR)'d':
+					if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_DATE),
+							type_name->cnt)) {
+						*c_sql = ES_DATE_TO_CSQL;
+						*sql = ES_DATE_TO_SQL;
 						return TRUE;
 					}
 					break;

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -709,7 +709,7 @@ SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body)
 	tout = dbc->timeout < stmt->query_timeout ? stmt->query_timeout :
 		dbc->timeout;
 
-	HDRH(dbc)->diag.state = SQL_STATE_00000;
+	RESET_HDIAG(dbc);
 	code = -1; /* init value */
 	if (dbc_curl_add_post_body(dbc, tout, u8body) &&
 		dbc_curl_perform(dbc, &code, &resp)) {
@@ -769,7 +769,7 @@ static SQLRETURN check_sql_api(esodbc_dbc_st *dbc)
 
 	if (code == 200) {
 		DBGH(dbc, "SQL API test succesful.");
-		dbc->hdr.diag.state = SQL_STATE_00000;
+		RESET_HDIAG(dbc);
 	} else if (0 < code) {
 		attach_error(dbc, &resp, code);
 	} else {
@@ -1209,7 +1209,7 @@ static SQLRETURN check_server_version(esodbc_dbc_st *dbc)
 		return ret;
 	}
 
-	HDRH(dbc)->diag.state = SQL_STATE_00000;
+	RESET_HDIAG(dbc);
 	if (! dbc_curl_perform(dbc, &code, &resp)) {
 		dbc_curl_post_diag(dbc, SQL_STATE_HY000);
 		cleanup_curl(dbc);
@@ -2420,15 +2420,12 @@ SQLRETURN EsSQLDriverConnectW
 			RET_HDIAGS(dbc, SQL_STATE_HY110);
 	}
 
-	HDRH(dbc)->diag.state = SQL_STATE_00000;
+	RESET_HDIAG(dbc);
 	if (! load_es_types(dbc)) {
 		ERRH(dbc, "failed to load Elasticsearch/SQL types.");
-		TRACE;
 		if (HDRH(dbc)->diag.state) {
-			TRACE;
 			RET_STATE(HDRH(dbc)->diag.state);
 		} else {
-			TRACE;
 			RET_HDIAG(dbc, SQL_STATE_HY000,
 				"failed to load Elasticsearch/SQL types", 0);
 		}

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1249,7 +1249,8 @@ static SQLRETURN check_server_version(esodbc_dbc_st *dbc)
 	/* re-read the original version (before trimming) and dup it */
 	ver_no.str = (SQLWCHAR *)UJReadString(o_number, &ver_no.cnt);
 	/* version is returned to application, which requires a NTS => +1 for \0 */
-	if (! (dbc->srv_ver.string.str = malloc(ver_no.cnt * sizeof(SQLWCHAR) + /*\0*/1))) {
+	dbc->srv_ver.string.str = malloc((ver_no.cnt + 1) * sizeof(SQLWCHAR));
+	if (! dbc->srv_ver.string.str) {
 		ERRNH(dbc, "OOM for %zd.", ver_no.cnt * sizeof(SQLWCHAR));
 		post_diagnostic(dbc, SQL_STATE_HY001, NULL, 0);
 		goto err;
@@ -1797,7 +1798,7 @@ static void set_display_size(esodbc_estype_st *es_type)
 	}
 
 	DBG("data type: %hd, display size: %lld", es_type->data_type,
-		es_type->data_type);
+		es_type->display_size);
 }
 
 static BOOL bind_types_cols(esodbc_stmt_st *stmt, estype_row_st *type_row)

--- a/driver/error.c
+++ b/driver/error.c
@@ -12,6 +12,9 @@
 void init_diagnostic(esodbc_diag_st *dest)
 {
 	dest->state = SQL_STATE_00000;
+	dest->text[0] = '\0';
+	dest->text_len = 0;
+	dest->native_code = 0;
 	dest->row_number = SQL_NO_ROW_NUMBER;
 	dest->column_number = SQL_NO_COLUMN_NUMBER;
 }

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -492,6 +492,9 @@ SQLRETURN EsSQLSetDescRec(
 /* set a diagnostic to a(ny) handle */
 #define SET_HDIAG(_hp/*handle ptr*/, _s/*tate*/, _t/*char text*/, _c/*ode*/) \
 	post_diagnostic(_hp, _s, MK_WPTR(_t), _c)
+/* reset handle diagnostic state */
+#define RESET_HDIAG(_hp/*handle ptr*/) \
+	init_diagnostic(&HDRH(dbc)->diag)
 
 /* return the code associated with the given state (and debug-log) */
 #define RET_STATE(_s)	\

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -69,6 +69,8 @@ static const char systypes_answer[] = "\
 			false, false, null, null, null, 12, 0, null, null],\
 		[\"BOOLEAN\", 16, 1, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, null, null, 16, 0, null, null],\
+		[\"DATE\", 91, 10, \"'\", \"'\", null, 2, false, 3, true, false,\
+			false, null, null, null, 91, 0, null, null],\
 		[\"DATETIME\", 93, 24, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, 3, 3, 9, 3, null, null],\
 		[\"INTERVAL_YEAR\", 101, 7, \"'\", \"'\", null, 2, false, 3, true,\

--- a/test/integration/ites.py
+++ b/test/integration/ites.py
@@ -84,7 +84,7 @@ def main():
 	if not (args.root_dir or args.es_reset or args.pre_staged):
 		parser.error("no Elasticsearch instance or root/staged directory provided.")
 
-	if not (args.driver or args.version or args.es_reset):
+	if not (args.driver or args.version or args.es_reset or args.pre_staged):
 		parser.error("don't know what Elasticsearch version to test against.")
 
 	try:


### PR DESCRIPTION
This PR adds initial support for the new DATE ES/SQL (runtime-only) data type (https://github.com/elastic/elasticsearch/pull/37693): the date type will be accepted by the driver and passed onto the application, but no data conversions are possible yet (should applications request them).

The PR also changes the connection testing: the "simple" query has been replaced by data type loading. This improves the testing by setting up the connection just like before "normal" operation would. (Specifically, data types misalignment would no longer be possible, when connection testing would work, but application connecting would later fail.)
 
A couple of fixes are also addressed:
* incorrect allocation for server version string (the space reservation for the null terminator had been done incorrectly); and 
* wrong data type structure member had been debug-logged previously.