### PR TITLE
Close cursor

### DIFF
--- a/driver/connect.h
+++ b/driver/connect.h
@@ -14,7 +14,8 @@
 BOOL connect_init();
 void connect_cleanup();
 
-SQLRETURN post_json(esodbc_stmt_st *stmt, const cstr_st *u8body);
+SQLRETURN dbc_curl_set_url(esodbc_dbc_st *dbc, int url_type);
+SQLRETURN post_json(esodbc_stmt_st *stmt, int url_type, const cstr_st *u8body);
 void cleanup_dbc(esodbc_dbc_st *dbc);
 SQLRETURN do_connect(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs);
 SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs);

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -127,6 +127,7 @@
 
 /* SQL plugin's REST endpoint for SQL */
 #define ELASTIC_SQL_PATH				"/_xpack/sql"
+#define ELASTIC_SQL_CLOSE_SUBPATH		"/close"
 
 /* initial receive buffer size for REST answers */
 #define ESODBC_BODY_BUF_START_SIZE		(4 * 1024)
@@ -300,14 +301,14 @@
 /*
  * System functions:
  * - supported: DATABASE, IFNULL, USER.
- * - not supported: none DATABASE, IFNULL, USER
+ * - not supported: none.
  */
 #define ESODBC_SYSTEM_FUNCTIONS					(0LU | \
 		SQL_FN_SYS_USERNAME | SQL_FN_SYS_DBNAME | SQL_FN_SYS_IFNULL)
 /*
  * Convert functions support:
- * - supported: CAST.
- * - not supported: CONVERT.
+ * - supported: CAST, CONVERT.
+ * - not supported: none.
  */
 #define ESODBC_CONVERT_FUNCTIONS				(0LU | \
 	SQL_FN_CVT_CONVERT | SQL_FN_CVT_CAST)
@@ -345,12 +346,27 @@
 #define ESODBC_SQL92_DATETIME_FUNCTIONS			0LU
 /*
  * SQL92 datetime literals support:
- * - supported: TIMESTAMP;
- * - not supported: DATE, TIME, INTERVAL: YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/
+ * - supported: TIMESTAMP, INTERVAL: YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/
  *   YEAR_TO_MONTH/DAY_TO_HOUR/DAY_TO_MINUTE/DAY_TO_SECOND/HOUR_TO_MINUTE/
  *   HOUR_TO_SECOND/MINUTE_TO_SECOND.
+ * - not supported: TIME.
  */
-#define ESODBC_DATETIME_LITERALS				SQL_DL_SQL92_TIMESTAMP
+#define ESODBC_DATETIME_LITERALS				(0LU | \
+		SQL_DL_SQL92_TIMESTAMP | \
+		SQL_DL_SQL92_DATE | \
+		SQL_DL_SQL92_INTERVAL_YEAR | \
+		SQL_DL_SQL92_INTERVAL_MONTH | \
+		SQL_DL_SQL92_INTERVAL_DAY | \
+		SQL_DL_SQL92_INTERVAL_HOUR | \
+		SQL_DL_SQL92_INTERVAL_MINUTE | \
+		SQL_DL_SQL92_INTERVAL_SECOND | \
+		SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH | \
+		SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR | \
+		SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE | \
+		SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND | \
+		SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE | \
+		SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND | \
+		SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND )
 /*
  * SQL92 value functions:
  * - supported: COALESCE, NULLIF

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -452,7 +452,6 @@ SQLRETURN EsSQLFreeStmt(SQLHSTMT StatementHandle, SQLUSMALLINT Option)
 		case SQL_CLOSE:
 			DBGH(stmt, "closing.");
 			clear_desc(stmt->ird, FALSE /*keep the header values*/);
-			// TODO: /_xpack/sql/close ? if still pending data?
 			break;
 
 		/* "Sets the SQL_DESC_COUNT field of the APD to 0, releasing all

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -113,7 +113,6 @@ static void init_desc(esodbc_desc_st *desc, esodbc_stmt_st *stmt,
 	if (DESC_TYPE_IS_APPLICATION(type)) {
 		desc->bind_type = SQL_BIND_BY_COLUMN;
 	}
-	// XXX: assign/chain to statement?
 }
 
 static void clear_desc(esodbc_desc_st *desc, BOOL reinit)
@@ -127,6 +126,9 @@ static void clear_desc(esodbc_desc_st *desc, BOOL reinit)
 			break;
 
 		case DESC_TYPE_IRD:
+			if (HDRH(desc)->stmt->rset.ecurs.cnt) {
+				close_es_cursor(HDRH(desc)->stmt);
+			}
 			if (STMT_HAS_RESULTSET(desc->hdr.stmt)) {
 				clear_resultset(desc->hdr.stmt, reinit);
 			}
@@ -350,17 +352,14 @@ SQLRETURN EsSQLFreeHandle(SQLSMALLINT HandleType, SQLHANDLE Handle)
 
 	switch(HandleType) {
 		case SQL_HANDLE_ENV: /* Environment Handle */
-			// TODO: check if there are connections (_DBC)
 			break;
 		case SQL_HANDLE_DBC: /* Connection Handle */
-			// TODO: remove from (potential) list?
 			dbc = DBCH(Handle);
 			/* app/DM should have SQLDisconnect'ed, but just in case  */
 			cleanup_dbc(dbc);
 			ESODBC_MUX_DEL(&dbc->curl_mux);
 			break;
 		case SQL_HANDLE_STMT:
-			// TODO: remove from (potential) list?
 			stmt = STMH(Handle);
 
 			detach_sql(stmt);
@@ -381,7 +380,6 @@ SQLRETURN EsSQLFreeHandle(SQLSMALLINT HandleType, SQLHANDLE Handle)
 			break;
 
 		case SQL_HANDLE_SENV: /* Shared Environment Handle */
-			// TODO: do I need to set the state into the Handle?
 			RET_STATE(SQL_STATE_HYC00);
 #if 0
 		case SQL_HANDLE_DBC_INFO_TOKEN:

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -135,6 +135,7 @@ typedef struct struct_dbc {
 		unsigned char checking; /* first letter of DSN config option */
 	} srv_ver; /* server version */
 	cstr_st url; /* SQL URL (posts) */
+	cstr_st close_url; /* SQL close URL (posts) */
 	cstr_st root_url; /* root URL (gets) */
 	enum {
 		ESODBC_SEC_NONE = 0,
@@ -165,6 +166,12 @@ typedef struct struct_dbc {
 	CURL *curl; /* cURL handle */
 	CURLcode curl_err;
 	char curl_err_buff[CURL_ERROR_SIZE];
+	enum {
+		ESODBC_CURL_NONE = 0, /* init value */
+		ESODBC_CURL_QUERY,
+		ESODBC_CURL_CLOSE,
+		ESODBC_CURL_ROOT
+	} crr_url; /* curl is set to 'url', 'close_url' or 'root_url' (above) */
 	char *abuff; /* buffer holding the answer */
 	size_t alen; /* size of abuff */
 	size_t apos; /* current write position in the abuff */

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -17,6 +17,8 @@ SQLRETURN TEST_API attach_sql(esodbc_stmt_st *stmt, const SQLWCHAR *sql,
 	size_t tlen);
 void detach_sql(esodbc_stmt_st *stmt);
 SQLRETURN TEST_API serialize_statement(esodbc_stmt_st *stmt, cstr_st *buff);
+SQLRETURN close_es_cursor(esodbc_stmt_st *stmt);
+SQLRETURN close_es_answ_handler(esodbc_stmt_st *stmt, char *buff, size_t blen);
 
 
 SQLRETURN EsSQLBindCol(

--- a/test/integration/install.py
+++ b/test/integration/install.py
@@ -25,7 +25,7 @@ class Installer(object):
 			print("WARNING: bitness misalignment between interpreter (%s) and driver (%s): testing will likely fail" %
 					(bitness_py, bitness_driver))
 
-	def _install_driver_win(self):
+	def _install_driver_win(self, ephemeral):
 		with psutil.Popen(["msiexec.exe", "/i", self._driver_path, "/norestart", "/quiet"]) as p:
 			waiting_since = time.time()
 			while p.poll() is None:
@@ -42,11 +42,12 @@ class Installer(object):
 				raise Exception("driver installation failed with code: %s (see "\
 						"https://docs.microsoft.com/en-us/windows/desktop/msi/error-codes)." % p.returncode)
 			print("Driver installed (%s)." % self._driver_path)
-			atexit.register(psutil.Popen, ["msiexec.exe", "/x", self._driver_path, "/norestart", "/quiet"])
+			if ephemeral:
+				atexit.register(psutil.Popen, ["msiexec.exe", "/x", self._driver_path, "/norestart", "/quiet"])
 
-	def install(self):
+	def install(self, ephemeral):
 		if os.name == "nt":
-			return self._install_driver_win()
+			return self._install_driver_win(ephemeral)
 		else:
 			raise Exception("unsupported OS: %s" % os.name)
 

--- a/test/integration/ites.py
+++ b/test/integration/ites.py
@@ -45,15 +45,16 @@ def ites(args):
 		print("Using pre-staged Elasticsearch.")
 
 	# add test data into it
-	if not (args.skip_indexing and args.skip_tests):
-		data = TestData(args.skip_indexing)
+	if args.reindex or not (args.skip_indexing and args.skip_tests):
+		data = TestData(TestData.MODE_NOINDEX if args.skip_indexing else TestData.MODE_REINDEX if args.reindex else \
+				TestData.MODE_INDEX)
 		data.load()
 
 	# install the driver
 	if args.driver:
 		driver_path = os.path.abspath(args.driver)
 		installer = Installer(driver_path)
-		installer.install()
+		installer.install(args.ephemeral)
 
 	# run the tests
 	if not args.skip_tests:
@@ -73,10 +74,15 @@ def main():
 
 	parser.add_argument("-d", "--driver", help="The path to the driver file to test; if not provided, the driver "
 			"is assumed to have been installed.")
-	parser.add_argument("-e", "--ephemeral", help="Remove the staged Elasticsearch after testing.",
-			action="store_true", default=False)
+	parser.add_argument("-e", "--ephemeral", help="Remove the staged Elasticsearch and installed driver after testing"
+			" if test is succesful.", action="store_true", default=False)
 	parser.add_argument("-t", "--skip-tests", help="Skip running the tests.", action="store_true", default=False)
-	parser.add_argument("-i", "--skip-indexing", help="Skip indexing test data.", action="store_true", default=False)
+
+	idx_grp = parser.add_mutually_exclusive_group()
+	idx_grp.add_argument("-i", "--skip-indexing", help="Skip indexing test data.", action="store_true", default=False)
+	idx_grp.add_argument("-x", "--reindex", help="Drop indices if any and (re)index test data.",
+			action="store_true", default=False)
+
 	parser.add_argument("-v", "--version", help="Elasticsearch version to test against; read from the driver file by "
 			"default.")
 

--- a/test/integration/ites.py
+++ b/test/integration/ites.py
@@ -75,7 +75,7 @@ def main():
 	parser.add_argument("-d", "--driver", help="The path to the driver file to test; if not provided, the driver "
 			"is assumed to have been installed.")
 	parser.add_argument("-e", "--ephemeral", help="Remove the staged Elasticsearch and installed driver after testing"
-			" if test is succesful.", action="store_true", default=False)
+			" if test is successful.", action="store_true", default=False)
 	parser.add_argument("-t", "--skip-tests", help="Skip running the tests.", action="store_true", default=False)
 
 	idx_grp = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
With this PR the driver will close a cursor received from ES/SQL
when the statement is closed (i.e. IRD cleared). This should release
faster any resources running against a timer in ES.

An integration test had been added for it as well.

The integration tests "framework" got a new CLI paramter, to force
data-reindexing. Also, the "ephemeral" paramter nwo controls the driver
uninstallation too.

The advertised driver capabilities are also updated to reflect the
progress on ES/SQL side.