### PR TITLE
Support for querying current user and catalog

### DIFF
--- a/driver/catalogue.h
+++ b/driver/catalogue.h
@@ -11,8 +11,8 @@
 #include "handles.h"
 
 
-SQLSMALLINT copy_current_catalog(esodbc_dbc_st *dbc, SQLWCHAR *dest,
-	SQLSMALLINT room);
+SQLSMALLINT fetch_server_attr(esodbc_dbc_st *dbc, SQLINTEGER attr_id,
+		SQLWCHAR *dest, SQLSMALLINT room);
 
 
 SQLRETURN EsSQLStatisticsW(

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -2756,7 +2756,9 @@ SQLRETURN EsSQLGetConnectAttrW(
 			if (! dbc->es_types) {
 				ERRH(dbc, "no connection active.");
 				RET_HDIAGS(dbc, SQL_STATE_08003);
-			} else if ((used = copy_current_catalog(dbc, (SQLWCHAR *)ValuePtr,
+			}
+			if ((used = fetch_server_attr(dbc, SQL_ATTR_CURRENT_CATALOG,
+							(SQLWCHAR *)ValuePtr,
 							(SQLSMALLINT)BufferLength)) < 0) {
 				ERRH(dbc, "failed to get current catalog.");
 				RET_STATE(dbc->hdr.diag.state);

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -239,6 +239,7 @@ SQLRETURN TEST_API attach_answer(esodbc_stmt_st *stmt, char *buff, size_t blen)
 		ERRH(stmt, "failed to decode JSON answer: %s ([%zu] `%.*s`).",
 			stmt->rset.state ? UJGetError(stmt->rset.state) : "<none>",
 			blen, blen, buff);
+		assert(0);
 		RET_HDIAG(stmt, SQL_STATE_HY000, MSG_INV_SRV_ANS, 0);
 	}
 	columns = rows = cursor = NULL;


### PR DESCRIPTION
This PR adds support for getting attribute values for current user
and catalog. This is being done by using the now available server-side
corresponding functions.

Close #72.