### PR TITLE
Allow disabling the cursor page size limit

### DIFF
--- a/driver/defs.h
+++ b/driver/defs.h
@@ -144,7 +144,7 @@
  * Config defaults
  */
 /* default maximum amount of bytes to accept in REST answers */
-#define ESODBC_DEF_MAX_BODY_SIZE_MB	"10"
+#define ESODBC_DEF_MAX_BODY_SIZE_MB	"100"
 /* max number of rows to request from server */
 #define ESODBC_DEF_FETCH_SIZE		"0" // no fetch size
 /* default host to connect to */


### PR DESCRIPTION
This PR allows the user to set the page size limit to 0, thus disabling it.
It also increases the default from 10MB to 100MB.
In case the limit is to be enforced, the libcurl callback will now fail faster, skipping a (useless) reallocation (that, until now, allowed copying partial data only before failing).