### PR TITLE
Change Connect button enabling condition

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -2362,6 +2362,9 @@ SQLRETURN EsSQLDriverConnectW
 		assert(0 < res);
 	}
 	assert(attrs.driver.cnt || attrs.dsn.cnt);
+	/* Note: SAVEFILE and FILEDSN are markers for the DM, not the driver. The
+	 * DM is supposed to read from / write into the file pointed to by these
+	 * attributes. */
 
 	if (attrs.dsn.cnt) {
 		/* "The driver uses any information it retrieves from the system

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -340,8 +340,15 @@ namespace EsOdbcDsnEditor
 
 		private void EnableDisableActionButtons()
 		{
-			saveButton.Enabled = string.IsNullOrEmpty(textName.Text) == false
-								 && string.IsNullOrEmpty(textHostname.Text) == false;
+			if (isConnecting) {
+				// If connecting, enable the button if we have a hostname.
+				// This can be triggered by app connecting or FileDSN verifying the connection.
+				saveButton.Enabled = string.IsNullOrEmpty(textHostname.Text) == false;
+			} else {
+				// If editing a (User/System) DSN, enable the buton if both DSN name and hostname are available.
+				saveButton.Enabled = string.IsNullOrEmpty(textName.Text) == false
+									 && string.IsNullOrEmpty(textHostname.Text) == false;
+			}
 			testButton.Enabled = string.IsNullOrEmpty(textHostname.Text) == false;
 		}
 


### PR DESCRIPTION
This PR changes the way the Connect/Save button is enabled:
- the Connect button is now enabled if the hostname field is populated;
- the Save button remains enabled only when both DSN name and hostname are available.

Close #95.