### PR TITLE
Workaround UJSON4C's parsing failure cause

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,11 +102,6 @@ if (${WIN32})
 	# 2MB stack size
 	# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:2097152")
 	# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /F 2097152")
-	# Force UJSON4C's Unicode decoder scratchpad onto the heap. Its large
-	# default size (128K) leads to high stack usage.
-	set(CMAKE_C_FLAGS
-		# defined to sizeof(wchar_t)
-		"${CMAKE_C_FLAGS} /DJSON_MAX_STACK_BUFFER_SIZE=2")
 
 	if (${IS_UNICODE})
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DUNICODE /D_UNICODE")


### PR DESCRIPTION
UJSON4C will fail to parse an object if past the indicated length there's white space => add a 0-terminator.

(The entire parsing in the library is unsafe without this 0-term, actually.)

Close #61.