### PR TITLE
Integration testing: increase timeouts for ES starting

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -12,6 +12,15 @@ set DRIVER_BASE_NAME=esodbc
 set ARG="%*"
 set SRC_PATH=%~dp0
 
+REM presence of 'help'/'?': invoke USAGE "function" and exit
+if /i not [%ARG:help=%] == [%ARG%] (
+	call:USAGE %0
+	goto END
+) else if not [%ARG:?=%] == [%ARG%] (
+	call:USAGE %0
+	goto END
+)
+
 call:SET_ARCH
 call:SET_CMAKE
 call:SET_PYTHON
@@ -21,15 +30,6 @@ call:SET_BUILDS_DIR
 REM
 REM  Perform the building steps
 REM
-
-REM presence of 'help'/'?': invoke USAGE "function" and exit
-if /i not [%ARG:help=%] == [%ARG%] (
-	call:USAGE %0
-	goto END
-) else if not [%ARG:?=%] == [%ARG%] (
-	call:USAGE %0
-	goto END
-)
 
 if /i not [%ARG:ctests=%] == [%ARG%] (
 	call:CTESTS

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -32,7 +32,8 @@ class Elasticsearch(object):
 	TERM_TIMEOUT = 5 # how long to wait for processes to die (before KILLing)
 	REQ_TIMEOUT = 20 # default GET request timeout
 	ES_PORT = 9200
-	ES_START_TIMEOUT = 30
+	ES_START_TIMEOUT = 60 # how long to wait for Elasticsearch to come online
+	ES_401_RETRIES = 8 # how many "starting" 401 answers to accept before giving up (.5s waiting inbetween)
 	AUTH_PASSWORD = "elastic"
 
 	def __init__(self):
@@ -142,7 +143,7 @@ class Elasticsearch(object):
 				failures += 1
 				# it seems that on a "fortunate" timing, ES will return a 401 when just starting, even if no
 				# authentication is enabled at this point: try to give it more time to start
-				if 3 < failures:
+				if self.ES_401_RETRIES < failures:
 					raise e
 			time.sleep(.5)
 			if self.ES_START_TIMEOUT < time.time() - waiting_since:

--- a/test/integration/testing.py
+++ b/test/integration/testing.py
@@ -11,7 +11,7 @@ import hashlib
 from elasticsearch import Elasticsearch
 from data import TestData
 
-CONNECT_STRING = 'Driver={Elasticsearch Driver};UID=elastic;PWD=%s;Secure=0' % Elasticsearch.AUTH_PASSWORD
+CONNECT_STRING = 'Driver={Elasticsearch Driver};UID=elastic;PWD=%s;Secure=0;' % Elasticsearch.AUTH_PASSWORD
 
 class Testing(object):
 


### PR DESCRIPTION
ES can take longer to start in a virtualized environment, so increased limits are needed.

`build.bat`: don't set any script variables if only printing the usage (and exit).