### PR TITLE
ODBC Installer API for system info DSN access

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -2384,7 +2384,7 @@ SQLRETURN EsSQLDriverConnectW
 		 * the information in the connection string." */
 		INFOH(dbc, "configuring the driver by DSN '" LWPDL "'.",
 			LWSTR(&attrs.dsn));
-		if (! read_system_info(&attrs)) {
+		if (! load_system_dsn(&attrs, /*overwrite?*/FALSE)) {
 			/* warn, but try to carry on */
 			WARNH(dbc, "failed to read system info for DSN '" LWPDL "' data.",
 				LWSTR(&attrs.dsn));
@@ -2393,7 +2393,7 @@ SQLRETURN EsSQLDriverConnectW
 				res = assign_dsn_attr(&attrs, &MK_WSTR(ESODBC_DSN_DSN),
 						&MK_WSTR("DEFAULT"), /*overwrite?*/TRUE);
 				assert(0 < res);
-				if (! read_system_info(&attrs)) {
+				if (! load_system_dsn(&attrs, /*overwrite?*/FALSE)) {
 					ERRH(dbc, "failed to read system info for default DSN.");
 					RET_HDIAGS(dbc, SQL_STATE_IM002);
 				}

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -89,9 +89,8 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 
 /* "system" from "system information" (cf. SQLDriverConnect), not as
  * in User/System DSN */
-BOOL read_system_info(esodbc_dsn_attrs_st *attrs);
 int system_dsn_exists(wstr_st *dsn);
-BOOL load_system_dsn(esodbc_dsn_attrs_st *attrs, SQLWCHAR *list00);
+BOOL load_system_dsn(esodbc_dsn_attrs_st *attrs, BOOL overwrite);
 BOOL write_system_dsn(esodbc_dsn_attrs_st *crr, esodbc_dsn_attrs_st *old);
 
 BOOL TEST_API parse_connection_string(esodbc_dsn_attrs_st *attrs,
@@ -99,6 +98,7 @@ BOOL TEST_API parse_connection_string(esodbc_dsn_attrs_st *attrs,
 long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 	SQLWCHAR *szConnStrOut, SQLSMALLINT cchConnStrOutMax);
 
+void log_installer_err();
 size_t copy_installer_errors(wchar_t *err_buff, size_t eb_max);
 int validate_dsn(esodbc_dsn_attrs_st *attrs, const wchar_t *dsn_str,
 	wchar_t *err_out, size_t eo_max, BOOL try_connect);


### PR DESCRIPTION
"Direct" registry access API was used to read the system info (DSN) on
connection establishment, if received connection string was not
sufficient.
This has now been replaced with existing code that uses ODBC Installer
API instead.

Close #107.