### PR TITLE
Init all record fields

### DIFF
--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -898,12 +898,12 @@ SQLRETURN  SQL_API SQLFetchScroll(SQLHSTMT StatementHandle,
 	SQLSMALLINT FetchOrientation, SQLLEN FetchOffset)
 {
 	SQLRETURN ret;
-	TRACE(_IN, StatementHandle, "phz", StatementHandle,
+	TRACE3(_IN, StatementHandle, "phz", StatementHandle,
 		FetchOrientation, FetchOffset);
 	HND_LOCK(StatementHandle);
 	ret = EsSQLFetchScroll(StatementHandle, FetchOrientation, FetchOffset);
 	HND_UNLOCK(StatementHandle);
-	TRACE(_OUT, StatementHandle, "dphz", ret, StatementHandle,
+	TRACE4(_OUT, StatementHandle, "dphz", ret, StatementHandle,
 		FetchOrientation, FetchOffset);
 	return ret;
 }

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -109,6 +109,7 @@ static SQLRETURN attach_columns(esodbc_stmt_st *stmt, UJObject columns)
 		MK_WPTR(JSON_ANSWER_COL_NAME),
 		MK_WPTR(JSON_ANSWER_COL_TYPE)
 	};
+	static const wstr_st EMPTY_WSTR = WSTR_INIT("");
 
 	ird = stmt->ird;
 	dbc = stmt->hdr.dbc;
@@ -180,15 +181,23 @@ static SQLRETURN attach_columns(esodbc_stmt_st *stmt, UJObject columns)
 		/* "If a base column name does not exist (as in the case of columns
 		 * that are expressions), then this variable contains an empty
 		 * string." */
-		rec->base_column_name = MK_WSTR("");
+		rec->base_column_name = EMPTY_WSTR;
 		/* "If a column does not have a label, the column name is returned. If
 		 * the column is unlabeled and unnamed, an empty string is ret" */
-		rec->label = rec->name.cnt ? rec->name : MK_WSTR("");
+		rec->label = rec->name.cnt ? rec->name : EMPTY_WSTR;
 
 		assert(rec->name.str && rec->label.str);
 		rec->unnamed = (rec->name.cnt || rec->label.cnt) ?
 			SQL_NAMED : SQL_UNNAMED;
 
+		/* All rec fields must be init'ed to a valid string in case their value
+		 * is requested (and written with write_wstr()). The values would
+		 * normally be provided by the data source, this is not the case here
+		 * (yet), though. */
+		rec->base_table_name = EMPTY_WSTR;
+		rec->catalog_name = EMPTY_WSTR;
+		rec->schema_name = EMPTY_WSTR;
+		rec->table_name = EMPTY_WSTR;
 #ifndef NDEBUG
 		//dump_record(rec);
 #endif /* NDEBUG */

--- a/driver/util.c
+++ b/driver/util.c
@@ -566,6 +566,7 @@ SQLRETURN write_wstr(SQLHANDLE hnd, SQLWCHAR *dest, wstr_st *src,
 				LWSTR(src), src->cnt, wide_avail);
 			RET_HDIAGS(hnd, SQL_STATE_01004);
 		} else {
+			assert(src->str);
 			wcsncpy(dest, src->str, src->cnt + /* 0-term */1);
 		}
 	} else {


### PR DESCRIPTION
Some of the string record fields have been left 0-ed, which is
problematic when their value is asked for. This PR inits them all to
the empty string, so that the transfer can take place.

(Their value would normally be provided by the data source, but this is
now not available with the current ES/SQL API.)

The PR also fixes two API tracing statements.