### PR TITLE
Integration testing: uninstall any old driver before attempting a new install

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -304,8 +304,8 @@ REM USAGE function: output a usage message
 	echo                  path can only be specified before the project/make
 	echo                  files are generated. (This does not run the
 	echo                  installer.^)
-	echo    regadd      : register the driver into the registry unde
-	echo                  'Elasticsearch ODBC' name;
+	echo    regadd      : register the driver into the registry under
+	echo                  'Elasticsearch ODBC' name; use along 'install' param
 	echo                  (needs Administrator privileges^).
 	echo    regdel      : deregister the driver from the registry;
 	echo                  (needs Administrator privileges^).
@@ -703,7 +703,7 @@ REM PACKAGE_DO function: generate deliverable package
 			goto END
 		)
 		echo %~nx0: Integration testing with: !X64_INSTALLER!.
-		!PY3_64! !SRC_PATH!\test\integration\ites.py -r !BUILD_DIR! -d !X64_INSTALLER!
+		!PY3_64! !SRC_PATH!\test\integration\ites.py -e -r !BUILD_DIR! -d !X64_INSTALLER!
 		if ERRORLEVEL 1 (
 			goto END
 		)
@@ -715,7 +715,7 @@ REM PACKAGE_DO function: generate deliverable package
 			goto END
 		)
 		echo %~nx0: Integration testing with: !X32_INSTALLER!.
-		!PY3_32! !SRC_PATH!\test\integration\ites.py -r !BUILD_DIR! -d !X32_INSTALLER!
+		!PY3_32! !SRC_PATH!\test\integration\ites.py -e -r !BUILD_DIR! -d !X32_INSTALLER!
 		if ERRORLEVEL 1 (
 			goto END
 		)
@@ -727,6 +727,15 @@ REM REGADD function: add driver into the registry
 :REGADD
 	echo %~nx0: adding driver into the registry.
 
+	REM check if build type and install path are known
+	if [%BUILD_TYPE%] == [] (
+		echo %~nx0: ERROR: unknown built type; use 'regadd' along 'install' parameter.
+		goto END
+	)
+	if [%INSTALL_DIR%] == [] (
+		echo %~nx0: ERROR: unknown install dir; use 'regadd' along 'install' parameter.
+		goto END
+	)
 	REM check if driver exists, otherwise the filename is unknown
 	if not exist %BUILD_DIR%\%BUILD_TYPE%\%DRIVER_BASE_NAME%*.dll (
 		echo %~nx0: ERROR: driver can only be added into the registry once built.

--- a/build.bat
+++ b/build.bat
@@ -305,8 +305,8 @@ REM USAGE function: output a usage message
 	echo                  files are generated. (This does not run the
 	echo                  installer.^)
 	echo    regadd      : register the driver into the registry under
-	echo                  'Elasticsearch ODBC' name; use along 'install' param
-	echo                  (needs Administrator privileges^).
+	echo                  'Elasticsearch ODBC' name; use alongside 'install'
+	echo                  param (needs Administrator privileges^).
 	echo    regdel      : deregister the driver from the registry;
 	echo                  (needs Administrator privileges^).
 	echo    tests       : (deprecated^) synonym with utests.
@@ -729,11 +729,11 @@ REM REGADD function: add driver into the registry
 
 	REM check if build type and install path are known
 	if [%BUILD_TYPE%] == [] (
-		echo %~nx0: ERROR: unknown built type; use 'regadd' along 'install' parameter.
+		echo %~nx0: ERROR: unknown build type; use 'regadd' when building new.
 		goto END
 	)
 	if [%INSTALL_DIR%] == [] (
-		echo %~nx0: ERROR: unknown install dir; use 'regadd' along 'install' parameter.
+		echo %~nx0: ERROR: unknown install dir; use 'regadd' alongside 'install' parameter.
 		goto END
 	)
 	REM check if driver exists, otherwise the filename is unknown

--- a/test/integration/install.py
+++ b/test/integration/install.py
@@ -7,16 +7,20 @@
 import os
 import time
 import psutil
+from subprocess import PIPE
 import ctypes
 import sys
 import atexit
 import tempfile
-import shutil
 
 from elasticsearch import Elasticsearch
 
+DRIVER_BASE_NAME = "Elasticsearch ODBC Driver"
+WMIC_UNINSTALL_TIMOUT = 30 # it can take quite long
+
 class Installer(object):
 	_driver_path = None
+	_driver_name = None
 
 	def __init__(self, path):
 		self._driver_path = path
@@ -27,20 +31,44 @@ class Installer(object):
 			print("WARNING: bitness misalignment between interpreter (%s) and driver (%s): testing will likely fail" %
 					(bitness_py, bitness_driver))
 
+		self._driver_name = "%s (%sbit)" % (DRIVER_BASE_NAME, bitness_driver)
+
 	def _install_driver_win(self, ephemeral):
+		# remove any old driver (of tested bitness)
+		name_filter = "name = '%s'" % self._driver_name
+		with psutil.Popen(["wmic", "/INTERACTIVE:OFF", "product", "where", name_filter, "call", "uninstall"],
+				stdout=PIPE, stderr=PIPE, universal_newlines=True) as p:
+			try:
+				p.wait(WMIC_UNINSTALL_TIMOUT)
+			except psutil.TimeoutExpired as e:
+				try: p.kill()
+				except: pass
+				raise Exception("wmic uninstallation killed after %s seconds" % WMIC_UNINSTALL_TIMOUT)
+
+			assert(p.returncode is not None)
+			out, err = p.communicate()
+			if (out): print(out)
+			if (err): print(err)
+			if p.returncode:
+				print("ERROR: driver wmic-uninstallation failed.")
+			else:
+				print("INFO: an old driver was %s." % ("uninstalled" if ("ReturnValue = 0" in out) else "not found"))
+
+
+		# get a file name to log the installation into
 		(fd, log_name) = tempfile.mkstemp(suffix="-installer.log")
 		os.close(fd)
 		if ephemeral:
-			atexit.register(shutil.rmtree, log_name, ignore_errors=True)
-
+			atexit.register(os.remove, log_name)
+		# install the new driver
 		with psutil.Popen(["msiexec.exe", "/i", self._driver_path, "/norestart", "/quiet", "/l*vx", log_name]) as p:
-			waiting_since = time.time()
-			while p.poll() is None:
-				time.sleep(.3)
-				if Elasticsearch.TERM_TIMEOUT < time.time() - waiting_since:
-					try: p.kill()
-					except: pass
-					raise Exception("installer killed after %s seconds" % Elasticsearch.TERM_TIMEOUT)
+			try:
+				p.wait(Elasticsearch.TERM_TIMEOUT)
+			except psutil.TimeoutExpired as e:
+				try: p.kill()
+				except: pass
+				raise Exception("installer killed after %s seconds" % Elasticsearch.TERM_TIMEOUT)
+
 			assert(p.returncode is not None)
 			if p.returncode:
 				if not ctypes.windll.shell32.IsUserAnAdmin():
@@ -53,6 +81,7 @@ class Installer(object):
 						print(text.decode("utf-16"))
 				except Exception as e:
 					print("ERROR: failed to read log of failed intallation: %s" % e)
+
 				raise Exception("driver installation failed with code: %s (see "\
 						"https://docs.microsoft.com/en-us/windows/desktop/msi/error-codes)." % p.returncode)
 			print("Driver installed (%s)." % self._driver_path)


### PR DESCRIPTION
- Uninstall an old driver if present before running the integration
tests.
- Switch on the ephemeral param, removing the drivers and testing
directories at end of (succesful) tests.

Additionally: 
- Check if build type and installation directories are set - and fail
quickly if they aren't - when setting up the development DSN in the
Registry.