### PR TITLE
Test: driver uninstallation done now with wmic only

### DIFF
--- a/test/integration/data.py
+++ b/test/integration/data.py
@@ -10,6 +10,7 @@ import csv
 import json
 import time
 import hashlib
+import os
 
 from elasticsearch import Elasticsearch
 
@@ -198,12 +199,16 @@ class TestData(object):
 	_csv_md5 = None
 	_csv_header = None
 	_csv_lines = None
+
+	_csvs_dir = None
 	_mode = None
 
-	def __init__(self, mode=MODE_INDEX):
+	def __init__(self, mode=MODE_INDEX, csvs_dir=None):
 		self._csv_md5 = {}
 		self._csv_header = {}
 		self._csv_lines = {}
+
+		self._csvs_dir = csvs_dir
 		self._mode = mode
 
 	def _csv_to_json_docs(self, csv_text):
@@ -256,24 +261,33 @@ class TestData(object):
 		header = stream.readline()
 		self._csv_header[index_name] = header.strip().split(",")
 
-	def _remote_csv_as_ndjson(self, url, index_name):
-		req = requests.get(url, timeout = Elasticsearch.REQ_TIMEOUT)
-		if req.status_code != 200:
-			raise Exception("failed to fetch %s with code %s" % (url, req.status_code))
-
-		#ndjson = csv_to_ndjson(req.text, index_name)
-		docs = self._csv_to_json_docs(req.text)
+	def _csv_as_ndjson(self, csv_text, encoding, index_name):
+		#ndjson = csv_to_ndjson(csv_text, index_name)
+		docs = self._csv_to_json_docs(csv_text)
 		ndjson = self._docs_to_ndjson(index_name, docs)
 
-		self._register_md5(index_name, req.text, req.encoding)
-		self._register_header(index_name, req.text)
+		self._register_md5(index_name, csv_text, encoding)
+		self._register_header(index_name, csv_text)
 		self._csv_lines[index_name] = len(docs)
 
 		return ndjson
 
+	def _get_csv_as_ndjson(self, base_url, csv_name, index_name):
+		if self._csvs_dir:
+			path = os.path.join(self._csvs_dir, csv_name)
+			with open(path, "rb") as f:
+				return self._csv_as_ndjson(f.read().decode("utf-8"), "utf-8", index_name)
+		else:
+			assert(base_url.endswith("/"))
+			url = base_url + csv_name
+			req = requests.get(url, timeout = Elasticsearch.REQ_TIMEOUT)
+			if req.status_code != 200:
+				raise Exception("failed to fetch %s with code %s" % (url, req.status_code))
+			return self._csv_as_ndjson(req.text, req.encoding, index_name)
+
+
 	def _prepare_tableau_load(self, file_name, index_name, index_template):
-		url = TABLEAU_DATASET_BASE_URL + file_name
-		ndjson = self._remote_csv_as_ndjson(url, index_name)
+		ndjson = self._get_csv_as_ndjson(TABLEAU_DATASET_BASE_URL, file_name, index_name)
 
 		if self.MODE_NOINDEX < self._mode:
 			with requests.put("http://localhost:%s/_template/%s_template" % (Elasticsearch.ES_PORT, index_name),
@@ -344,14 +358,14 @@ class TestData(object):
 			self._wait_for_results(self.STAPLES_INDEX)
 
 	def _load_elastic_library(self):
-		ndjson = self._remote_csv_as_ndjson(ES_DATASET_BASE_URL + self.LIBRARY_FILE, self.LIBRARY_INDEX)
+		ndjson = self._get_csv_as_ndjson(ES_DATASET_BASE_URL, self.LIBRARY_FILE, self.LIBRARY_INDEX)
 		if self.MODE_NOINDEX < self._mode:
 			self._delete_if_needed(self.LIBRARY_INDEX)
 			self._post_ndjson(ndjson, self.LIBRARY_INDEX)
 			self._wait_for_results(self.LIBRARY_INDEX)
 
 	def _load_elastic_employees(self):
-		ndjson = self._remote_csv_as_ndjson(ES_DATASET_BASE_URL + self.EMPLOYEES_FILE, self.EMPLOYEES_INDEX)
+		ndjson = self._get_csv_as_ndjson(ES_DATASET_BASE_URL, self.EMPLOYEES_FILE, self.EMPLOYEES_INDEX)
 		if self.MODE_NOINDEX < self._mode:
 			self._delete_if_needed(self.EMPLOYEES_INDEX)
 			self._post_ndjson(ndjson, self.EMPLOYEES_INDEX)

--- a/test/integration/data.py
+++ b/test/integration/data.py
@@ -200,15 +200,15 @@ class TestData(object):
 	_csv_header = None
 	_csv_lines = None
 
-	_csvs_dir = None
+	_offline_dir = None
 	_mode = None
 
-	def __init__(self, mode=MODE_INDEX, csvs_dir=None):
+	def __init__(self, mode=MODE_INDEX, offline_dir=None):
 		self._csv_md5 = {}
 		self._csv_header = {}
 		self._csv_lines = {}
 
-		self._csvs_dir = csvs_dir
+		self._offline_dir = offline_dir
 		self._mode = mode
 
 	def _csv_to_json_docs(self, csv_text):
@@ -273,8 +273,8 @@ class TestData(object):
 		return ndjson
 
 	def _get_csv_as_ndjson(self, base_url, csv_name, index_name):
-		if self._csvs_dir:
-			path = os.path.join(self._csvs_dir, csv_name)
+		if self._offline_dir:
+			path = os.path.join(self._offline_dir, csv_name)
 			with open(path, "rb") as f:
 				return self._csv_as_ndjson(f.read().decode("utf-8"), "utf-8", index_name)
 		else:

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -112,18 +112,15 @@ class Elasticsearch(object):
 
 	@staticmethod
 	def _stop_es(es_proc):
-		try:
-			children = es_proc.children()
-			children.append(es_proc)
-			for child in children:
-				child.terminate()
-			gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
-			for child in alive:
-				child.kill()
+		children = es_proc.children()
+		children.append(es_proc)
+		for child in children:
+			child.terminate()
+		gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
+		for child in alive:
+			child.kill()
 
-			print("Elasticsearch stopped.")
-		except Exception as e:
-			print("ERROR: failed to stop Elasticsearch cleanly: %s" % e)
+		print("Elasticsearch stopped.")
 
 	def _start_elasticsearch(self, es_dir):
 		start_script = os.path.join(es_dir, "bin", "elasticsearch")

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -37,8 +37,14 @@ class Elasticsearch(object):
 	ES_401_RETRIES = 8 # how many "starting" 401 answers to accept before giving up (.5s waiting inbetween)
 	AUTH_PASSWORD = "elastic"
 
-	def __init__(self):
-		pass
+	_offline_dir = None
+
+	def __init__(self, offline_dir=None):
+		self._offline_dir = offline_dir
+
+	@staticmethod
+	def elasticsearch_distro_filename(version):
+		return "%s-%s%s.%s" % (ES_PROJECT, version, ES_ARCH, PACKAGING)
 
 	def _latest_build(self, version):
 		req = requests.get(ARTIF_URL, timeout=self.REQ_TIMEOUT)
@@ -51,7 +57,7 @@ class Elasticsearch(object):
 		builds = req.json()["builds"]
 
 		# file name to download
-		file_name = "%s-%s%s.%s" % (ES_PROJECT, version, ES_ARCH, PACKAGING)
+		file_name = Elasticsearch.elasticsearch_distro_filename(version)
 
 		# Determine the most recent build
 		latest_et = datetime(1, 1, 1) # latest end_time
@@ -90,16 +96,27 @@ class Elasticsearch(object):
 		return (dest_file, size)
 
 	def _fetch_elasticsearch(self, version, dest_dir):
-		print("Fetching Elasticsearch from %s: " % ARTIF_URL)
-		start_ts = time.time()
-		url = self._latest_build(version)
-		delta = time.time() - start_ts
-		print("- latest build URL determined in: %.2f sec." % delta)
+		if self._offline_dir:
+			print("Copying Elasticsearch from %s. " % self._offline_dir)
+			file_name = Elasticsearch.elasticsearch_distro_filename(version)
+			src_path = os.path.join(self._offline_dir, file_name)
+			if not os.path.isfile(src_path):
+				raise Exception("Can't find %s in offline dir %s" % (file_name, self._offline_dir))
+			dest_file = os.path.join(dest_dir, file_name)
+			shutil.copyfile(src_path, dest_file)
+		else:
+			print("Fetching Elasticsearch from %s: " % ARTIF_URL)
+			start_ts = time.time()
+			url = self._latest_build(version)
+			delta = time.time() - start_ts
+			print("- latest build URL determined in: %.2f sec." % delta)
 
-		start_ts = time.time()
-		dest_file, size = self._download_build(url, dest_dir)
-		delta = time.time() - start_ts
-		print("- build of size %.2fMB downloaded in %.2f sec (%.2f Mbps)." % (size/M1, delta, (8 * size)/(M1 * delta)))
+			start_ts = time.time()
+			dest_file, size = self._download_build(url, dest_dir)
+			delta = time.time() - start_ts
+			print("- build of size %.2fMB downloaded in %.2f sec (%.2f Mbps)." % (size/M1, delta,
+				(8 * size)/(M1 * delta)))
+
 		return dest_file
 
 	def _update_es_yaml(self, es_dir):
@@ -113,12 +130,17 @@ class Elasticsearch(object):
 	@staticmethod
 	def _stop_es(es_proc):
 		children = es_proc.children()
-		children.append(es_proc)
 		for child in children:
-			child.terminate()
-		gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
-		for child in alive:
-			child.kill()
+			child.terminate() # == kill on Win
+		children.append(es_proc)
+		try:
+			gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
+			for child in alive:
+				child.kill()
+		except Exception as e:
+			# just a warning: the batch starting ES will die after java.exe exits and psutil can throw an exception
+			# about the (.bat) process no longer existing
+			print("WARN: while killing ES: %s." % e)
 
 		print("Elasticsearch stopped.")
 
@@ -172,7 +194,7 @@ class Elasticsearch(object):
 
 		pwd = self._gen_passwords(es_dir)
 		# change passwords, easier to restart with failed tests
-		req = requests.post("http://localhost:%s/_security/user/_password" % self.ES_PORT, auth=("elastic", pwd), 
+		req = requests.post("http://localhost:%s/_security/user/_password" % self.ES_PORT, auth=("elastic", pwd),
 				json={"password": self.AUTH_PASSWORD})
 		if req.status_code != 200:
 			raise Exception("attempt to change elastic's password failed with code %s" % req.status_code)
@@ -186,7 +208,7 @@ class Elasticsearch(object):
 		stage_dir = tempfile.mkdtemp(suffix=".ITES", dir=root_dir)
 		if ephemeral:
 			atexit.register(shutil.rmtree, stage_dir, ignore_errors=True)
-		
+
 		es_build = self._fetch_elasticsearch(version, stage_dir)
 		print("ES fetched to: %s" % es_build)
 

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -112,15 +112,18 @@ class Elasticsearch(object):
 
 	@staticmethod
 	def _stop_es(es_proc):
-		children = es_proc.children()
-		children.append(es_proc)
-		for child in children:
-			child.terminate()
-		gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
-		for child in alive:
-			child.kill()
+		try:
+			children = es_proc.children()
+			children.append(es_proc)
+			for child in children:
+				child.terminate()
+			gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
+			for child in alive:
+				child.kill()
 
-		print("Elasticsearch stopped.")
+			print("Elasticsearch stopped.")
+		except Exception as e:
+			print("ERROR: failed to stop Elasticsearch cleanly: %s" % e)
 
 	def _start_elasticsearch(self, es_dir):
 		start_script = os.path.join(es_dir, "bin", "elasticsearch")

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -112,13 +112,18 @@ class Elasticsearch(object):
 
 	@staticmethod
 	def _stop_es(es_proc):
-		children = es_proc.children()
-		children.append(es_proc)
-		for child in children:
-			try: child.kill()
-			except: pass
+		try:
+			children = es_proc.children()
+			children.append(es_proc)
+			for child in children:
+				child.terminate()
+			gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
+			for child in alive:
+				child.kill()
 
-		print("Elasticsearch stopped.")
+			print("Elasticsearch stopped.")
+		except Exception as e:
+			print("ERROR: failed to stop Elasticsearch cleanly: %s" % e)
 
 	def _start_elasticsearch(self, es_dir):
 		start_script = os.path.join(es_dir, "bin", "elasticsearch")

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -112,18 +112,13 @@ class Elasticsearch(object):
 
 	@staticmethod
 	def _stop_es(es_proc):
-		try:
-			children = es_proc.children()
-			children.append(es_proc)
-			for child in children:
-				child.terminate()
-			gone, alive = psutil.wait_procs(children, timeout=Elasticsearch.TERM_TIMEOUT)
-			for child in alive:
-				child.kill()
+		children = es_proc.children()
+		children.append(es_proc)
+		for child in children:
+			try: child.kill()
+			except: pass
 
-			print("Elasticsearch stopped.")
-		except Exception as e:
-			print("ERROR: failed to stop Elasticsearch cleanly: %s" % e)
+		print("Elasticsearch stopped.")
 
 	def _start_elasticsearch(self, es_dir):
 		start_script = os.path.join(es_dir, "bin", "elasticsearch")

--- a/test/integration/ites.py
+++ b/test/integration/ites.py
@@ -17,7 +17,7 @@ from testing import Testing
 
 
 def ites(args):
-	es = Elasticsearch()
+	es = Elasticsearch(args.offline_dir)
 
 	# create a running instance of Elasticsearch if needed
 	if not args.pre_staged:
@@ -53,7 +53,7 @@ def ites(args):
 		else:
 			test_mode = TestData.MODE_INDEX
 
-		data = TestData(test_mode, args.csvs_dir)
+		data = TestData(test_mode, args.offline_dir)
 		data.load()
 
 	# install the driver
@@ -80,8 +80,8 @@ def main():
 
 	parser.add_argument("-d", "--driver", help="The path to the driver file to test; if not provided, the driver "
 			"is assumed to have been installed.")
-	parser.add_argument("-c", "--csvs_dir", help="The directory path holding the CSV files to load as test data, "
-			"as opposed to default remote built-in URLs.")
+	parser.add_argument("-o", "--offline_dir", help="The directory path holding the files to copy the test data from, "
+			"as opposed to downloading them.")
 	parser.add_argument("-e", "--ephemeral", help="Remove the staged Elasticsearch and installed driver after testing"
 			" if test is successful.", action="store_true", default=False)
 	parser.add_argument("-t", "--skip-tests", help="Skip running the tests.", action="store_true", default=False)

--- a/test/integration/ites.py
+++ b/test/integration/ites.py
@@ -46,8 +46,14 @@ def ites(args):
 
 	# add test data into it
 	if args.reindex or not (args.skip_indexing and args.skip_tests):
-		data = TestData(TestData.MODE_NOINDEX if args.skip_indexing else TestData.MODE_REINDEX if args.reindex else \
-				TestData.MODE_INDEX)
+		if args.skip_indexing:
+			test_mode = TestData.MODE_NOINDEX
+		elif args.reindex:
+			test_mode = TestData.MODE_REINDEX
+		else:
+			test_mode = TestData.MODE_INDEX
+
+		data = TestData(test_mode, args.csvs_dir)
 		data.load()
 
 	# install the driver
@@ -74,6 +80,8 @@ def main():
 
 	parser.add_argument("-d", "--driver", help="The path to the driver file to test; if not provided, the driver "
 			"is assumed to have been installed.")
+	parser.add_argument("-c", "--csvs_dir", help="The directory path holding the CSV files to load as test data, "
+			"as opposed to default remote built-in URLs.")
 	parser.add_argument("-e", "--ephemeral", help="Remove the staged Elasticsearch and installed driver after testing"
 			" if test is successful.", action="store_true", default=False)
 	parser.add_argument("-t", "--skip-tests", help="Skip running the tests.", action="store_true", default=False)


### PR DESCRIPTION
This PR replaces the driver uninstalling with `msiexec` (old method) with `wmic` (new method) to avoid the restart manager occasionally signaling the calling process (due to : `RESTART MANAGER: Detected that application with id 21128, friendly name 'Python', of type RmConsole and status 1 holds file[s] in use.`).

Also, add an offline working mode, where the files otherwise downloaded are accessed from a local folder.