### PR TITLE
Test: add Kibana's sample data to the tests

### DIFF
--- a/test/integration/data.py
+++ b/test/integration/data.py
@@ -145,7 +145,7 @@ STAPLES_TEMPLATE =\
 
 ES_DATASET_BASE_URL = "https://raw.githubusercontent.com/elastic/elasticsearch/6857d305270be3d987689fda37cc84b7bc18fbb3/x-pack/plugin/sql/qa/src/main/resources/"
 
-KIBANA_SAMPLES_BASE_URL = "https://raw.githubusercontent.com/elastic/kibana/master/src/legacy/server/sample_data/data_sets"
+KIBANA_SAMPLES_BASE_URL = "https://raw.githubusercontent.com/elastic/kibana/54e498200b8b1a265becf1b27a6958e613acc3d1/src/legacy/server/sample_data/data_sets"
 KIBANA_INDEX_PREFIX = "kibana_sample_data_"
 
 # python seems to slow down when operating on multiple long strings?

--- a/test/integration/testing.py
+++ b/test/integration/testing.py
@@ -79,6 +79,16 @@ class Testing(object):
 					curs2.fetchall()
 		# no exception raised -> passed
 
+	def _select_columns(self, index_name, columns):
+		with pyodbc.connect(self._dsn) as cnxn:
+			cnxn.autocommit = True
+			stmt = "select %s from %s" % (columns, index_name)
+			with cnxn.execute(stmt) as curs:
+				cnt = 0
+				while curs.fetchone():
+					cnt += 1 # no exception -> success
+				print("Selected %s rows from %s." % (cnt, index_name))
+
 	def _current_user(self):
 		with pyodbc.connect(self._dsn) as cnxn:
 			cnxn.autocommit = True
@@ -87,12 +97,14 @@ class Testing(object):
 				raise Exception("current username not 'elastic': %s" % user)
 
 	def perform(self):
+		self._current_user()
 		self._as_csv(TestData.LIBRARY_INDEX)
 		self._as_csv(TestData.EMPLOYEES_INDEX)
 		self._count_all(TestData.CALCS_INDEX)
 		self._count_all(TestData.STAPLES_INDEX)
 		self._clear_cursor(TestData.LIBRARY_INDEX)
-		self._current_user()
+		self._select_columns(TestData.FLIGHTS_INDEX, "*")
+		# TODO: add ecommerce and logs once #39700 is addressed
 
 		print("Tests successful.")
 


### PR DESCRIPTION
This PR will load and use Kibana's sample data sets for the integration testing:
- index the currently three data sets into the local node;
- select and fetch all the columns from the "flights" set.

The "ecommerce" and "logs" sets require server-side changes to be able to use them (i.e. dealing with array fields).