### PR TITLE
Add request params for multi-value fields and timezone

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1278,6 +1278,11 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 		goto err;
 	}
 
+	/* "multifield leniency" param */
+	dbc->mfield_lenient = wstr2bool(&attrs->mfield_lenient);
+	INFOH(dbc, "multifield lenient: %s.",
+		dbc->mfield_lenient ? "true" : "false");
+
 	return SQL_SUCCESS;
 err:
 	/* release allocated resources before the failure; not the diag, tho */
@@ -2611,6 +2616,10 @@ SQLRETURN EsSQLDriverConnectW
 
 #ifdef TESTING
 		case ESODBC_SQL_DRIVER_TEST:
+			ret = config_dbc(dbc, &attrs);
+			if (! SQL_SUCCEEDED(ret)) {
+				RET_HDIAGS(dbc, SQL_STATE_HY000);
+			}
 			/* abusing the window handler to pass type data for non-network
 			 * tests (see load_es_types()). */
 			assert(! dbc->hwin);

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -175,6 +175,7 @@
 #define ESODBC_PWD_VAL_SUBST		"<redacted>"
 /* default version checking mode: strict, major, none (dbg only) */
 #define ESODBC_DEF_VERSION_CHECKING	ESODBC_DSN_VC_STRICT
+#define ESODBC_DEF_MFIELD_LENIENT	"true"
 
 /*
  *

--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -77,6 +77,7 @@ int assign_dsn_attr(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_APPLY_TZ), &attrs->apply_tz},
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
+		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -408,6 +409,7 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_APPLY_TZ), &attrs->apply_tz},
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
+		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -673,6 +675,11 @@ BOOL write_system_dsn(esodbc_dsn_attrs_st *new_attrs,
 			old_attrs ? &old_attrs->version_checking : NULL
 		},
 		{
+			&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT),
+			&new_attrs->mfield_lenient,
+			old_attrs ? &old_attrs->mfield_lenient : NULL
+		},
+		{
 			&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &new_attrs->trace_enabled,
 			old_attrs ? &old_attrs->trace_enabled : NULL
 		},
@@ -760,6 +767,7 @@ long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 		{&attrs->apply_tz, &MK_WSTR(ESODBC_DSN_APPLY_TZ)},
 		{&attrs->sci_floats, &MK_WSTR(ESODBC_DSN_SCI_FLOATS)},
 		{&attrs->version_checking, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING)},
+		{&attrs->mfield_lenient, &MK_WSTR(ESODBC_DSN_MFIELD_LENIENT)},
 		{&attrs->trace_enabled, &MK_WSTR(ESODBC_DSN_TRACE_ENABLED)},
 		{&attrs->trace_file, &MK_WSTR(ESODBC_DSN_TRACE_FILE)},
 		{&attrs->trace_level, &MK_WSTR(ESODBC_DSN_TRACE_LEVEL)},
@@ -850,6 +858,9 @@ void assign_dsn_defaults(esodbc_dsn_attrs_st *attrs)
 	res |= assign_dsn_attr(attrs,
 			&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &MK_WSTR(ESODBC_DEF_SCI_FLOATS),
 			/*overwrite?*/FALSE);
+	res |= assign_dsn_attr(attrs,
+			&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT),
+			&MK_WSTR(ESODBC_DEF_MFIELD_LENIENT), /*overwrite?*/FALSE);
 
 	/* default: no trace file */
 	res |= assign_dsn_attr(attrs,

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -36,6 +36,7 @@
 #define ESODBC_DSN_APPLY_TZ			"ApplyTZ"
 #define ESODBC_DSN_SCI_FLOATS		"ScientificFloats"
 #define ESODBC_DSN_VERSION_CHECKING	"VersionChecking"
+#define ESODBC_DSN_MFIELD_LENIENT	"MultiFieldLenient"
 #define ESODBC_DSN_TRACE_ENABLED	"TraceEnabled"
 #define ESODBC_DSN_TRACE_FILE		"TraceFile"
 #define ESODBC_DSN_TRACE_LEVEL		"TraceLevel"
@@ -75,10 +76,11 @@ typedef struct {
 	wstr_st apply_tz;
 	wstr_st sci_floats;
 	wstr_st version_checking;
+	wstr_st mfield_lenient;
 	wstr_st trace_enabled;
 	wstr_st trace_file;
 	wstr_st trace_level;
-#define ESODBC_DSN_ATTRS_COUNT	24
+#define ESODBC_DSN_ATTRS_COUNT	25
 	SQLWCHAR buff[ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN];
 	/* DSN reading/writing functions are passed a SQLSMALLINT lenght param */
 #if SHRT_MAX < ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -2226,8 +2226,8 @@ static SQLSMALLINT sqlctype_to_es(SQLSMALLINT c_concise)
 		case SQL_C_DATE:
 		case SQL_C_TIME:
 		case SQL_C_TIMESTAMP:
-		/* case SQL_C_TYPE_TIME_WITH_TIMEZONE:
-		case SQL_C_TYPE_TIMESTAMP_WITH_TIMEZONE: */
+			/* case SQL_C_TYPE_TIME_WITH_TIMEZONE:
+			case SQL_C_TYPE_TIMESTAMP_WITH_TIMEZONE: */
 			break;
 	}
 	WARN("no C to ES SQL mapping exists for C type %hd.", c_concise);
@@ -2296,7 +2296,7 @@ static BOOL consistency_check(esodbc_rec_st *rec)
 					es_type = lookup_es_type(dbc, concise_type, 0);
 					if (! es_type) {
 						BUGH(desc, "type lookup failed for concise type: %hd,"
-								" desc type: %d", concise_type, desc->type);
+							" desc type: %d", concise_type, desc->type);
 						return FALSE;
 					}
 					column_size = es_type->column_size;

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -162,6 +162,7 @@ typedef struct struct_dbc {
 		ESODBC_FLTS_SCIENTIFIC,
 		ESODBC_FLTS_AUTO,
 	} sci_floats; /* floats printing on conversion */
+	BOOL mfield_lenient; /* 'field_multi_value_leniency' request param */
 
 	esodbc_estype_st *es_types; /* array with ES types */
 	SQLULEN no_types; /* number of types in array */

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -34,6 +34,9 @@ static BOOL driver_init()
 	if (! connect_init()) {
 		return FALSE;
 	}
+	if (! queries_init()) {
+		return FALSE;
+	}
 #ifndef NDEBUG
 	if (_gf_log) {
 		ERR("leak reporting: on."); /* force create the log handle */

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -9,6 +9,7 @@
 #include "error.h"
 #include "handles.h"
 
+BOOL TEST_API queries_init();
 void clear_resultset(esodbc_stmt_st *stmt, BOOL on_close);
 SQLRETURN TEST_API attach_answer(esodbc_stmt_st *stmt, char *buff,
 	size_t blen);
@@ -138,6 +139,8 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #else /* _WIN64 */
 #	define JSON_KEY_CLT_ID		", \"client_id\": \"odbc32\"" /* n-th k. */
 #endif /* _WIN64 */
+#define JSON_KEY_MULTIVAL		", \"field_multi_value_leniency\": " /* n-th */
+#define JSON_KEY_TIMEZONE		", \"time_zone\": " /* n-th key */
 
 
 #endif /* __QUERIES_H__ */

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -191,10 +191,17 @@ class Elasticsearch(object):
 	def _enable_xpack(self, es_dir):
 		# start trial mode
 		url = "http://localhost:%s/_license/start_trial?acknowledge=true" % self.ES_PORT
-		req = requests.post(url)
-		if req.status_code != 200:
-			raise Exception("starting of trial failed with status: %s, text: %s" % (req.status_code, req.text))
-		# TODO: check content?
+		failures = 0
+		while True:
+			req = requests.post(url)
+			if req.status_code == 200:
+				# TODO: check content?
+				break
+			print("starting of trial failed (#%s) with status: %s, text: %s" % (failures, req.status_code, req.text))
+			failures += 1
+			if self.ES_401_RETRIES < failures:
+				raise Exception("starting of trial failed with status: %s, text: %s" % (req.status_code, req.text))
+			time.sleep(.5)
 
 		# setup passwords to random generated ones first...
 		pwd = self._gen_passwords(es_dir)

--- a/test/test_conversion_c2sql_boolean.cc
+++ b/test/test_conversion_c2sql_boolean.cc
@@ -23,7 +23,7 @@ class ConvertC2SQL_Boolean : public ::testing::Test, public ConnectedDBC {
 
 TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLCHAR val[] = "1";
 	SQLLEN osize = SQL_NTSL;
@@ -38,6 +38,7 @@ TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -45,7 +46,7 @@ TEST_F(ConvertC2SQL_Boolean, CStr2Boolean) /* note: test name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLWCHAR val[] = L"0X";
 	SQLLEN osize = sizeof(val[0]);
@@ -59,6 +60,7 @@ TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -66,7 +68,7 @@ TEST_F(ConvertC2SQL_Boolean, WStr2Boolean) /* note: test name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Smallint2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLSMALLINT val = 1;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_SSHORT,
@@ -80,6 +82,7 @@ TEST_F(ConvertC2SQL_Boolean, Smallint2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Smallint2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -87,7 +90,7 @@ TEST_F(ConvertC2SQL_Boolean, Smallint2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, UShort2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLUSMALLINT val = 0;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_USHORT,
@@ -101,6 +104,7 @@ TEST_F(ConvertC2SQL_Boolean, UShort2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"UShort2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -108,7 +112,7 @@ TEST_F(ConvertC2SQL_Boolean, UShort2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, LongLong2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLBIGINT val = 1;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_SBIGINT,
@@ -122,6 +126,7 @@ TEST_F(ConvertC2SQL_Boolean, LongLong2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"LongLong2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -129,7 +134,7 @@ TEST_F(ConvertC2SQL_Boolean, LongLong2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Float2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLREAL val = 1.11f;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_FLOAT,
@@ -143,6 +148,7 @@ TEST_F(ConvertC2SQL_Boolean, Float2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -150,7 +156,7 @@ TEST_F(ConvertC2SQL_Boolean, Float2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Double2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLDOUBLE val = 1.11;
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_DOUBLE,
@@ -164,6 +170,7 @@ TEST_F(ConvertC2SQL_Boolean, Double2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -171,7 +178,7 @@ TEST_F(ConvertC2SQL_Boolean, Double2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Numeric2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQL_NUMERIC_STRUCT val;
 	val.sign = 0;
@@ -190,6 +197,7 @@ TEST_F(ConvertC2SQL_Boolean, Numeric2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": true}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -197,7 +205,7 @@ TEST_F(ConvertC2SQL_Boolean, Numeric2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Binary2Boolean) /* note: name used in test */
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLCHAR val = 0;
 	SQLLEN indlen = sizeof(val);
@@ -212,6 +220,7 @@ TEST_F(ConvertC2SQL_Boolean, Binary2Boolean) /* note: name used in test */
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Binary2Boolean\", "
 		"\"params\": [{\"type\": \"BOOLEAN\", \"value\": false}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -219,7 +228,7 @@ TEST_F(ConvertC2SQL_Boolean, Binary2Boolean) /* note: name used in test */
 
 TEST_F(ConvertC2SQL_Boolean, Binary2Boolean_fail_22003)
 {
-  prepareStatement();
+	prepareStatement();
 
 	SQLCHAR val[2] = {1};
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY,

--- a/test/test_conversion_c2sql_interval.cc
+++ b/test/test_conversion_c2sql_interval.cc
@@ -38,6 +38,7 @@ TEST_F(ConvertC2SQL_Interval, Bit2Interval_year)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bit2Interval_year\", "
 		"\"params\": [{\"type\": \"INTERVAL_YEAR\", "
 		"\"value\": \"P1Y\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -60,6 +61,7 @@ TEST_F(ConvertC2SQL_Interval, Short2Interval_month)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Interval_month\", "
 		"\"params\": [{\"type\": \"INTERVAL_MONTH\", "
 		"\"value\": \"P-2M\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -82,6 +84,7 @@ TEST_F(ConvertC2SQL_Interval, Short2Interval_month_all_0)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Interval_month_all_0\", "
 		"\"params\": [{\"type\": \"INTERVAL_MONTH\", "
 		"\"value\": \"P0M\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -104,6 +107,7 @@ TEST_F(ConvertC2SQL_Interval, Integer2Interval_day)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Integer2Interval_day\", "
 		"\"params\": [{\"type\": \"INTERVAL_DAY\", "
 		"\"value\": \"P-3D\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -126,6 +130,7 @@ TEST_F(ConvertC2SQL_Interval, UBigInt2Interval_minute)
 	cstr_st expect = CSTR_INIT("{\"query\": \"UBigInt2Interval_minute\", "
 		"\"params\": [{\"type\": \"INTERVAL_MINUTE\", "
 		"\"value\": \"PT12345678M\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -148,6 +153,7 @@ TEST_F(ConvertC2SQL_Interval, SBigInt2Interval_second)
 	cstr_st expect = CSTR_INIT("{\"query\": \"SBigInt2Interval_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_SECOND\", "
 		"\"value\": \"PT-123456789S\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -171,6 +177,7 @@ TEST_F(ConvertC2SQL_Interval, SBigInt2Interval_second_all_0)
 		"{\"query\": \"SBigInt2Interval_second_all_0\", "
 		"\"params\": [{\"type\": \"INTERVAL_SECOND\", "
 		"\"value\": \"PT0S\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -194,6 +201,7 @@ TEST_F(ConvertC2SQL_Interval, WStr2Interval_day_to_second)
 		"{\"query\": \"WStr2Interval_day_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_DAY_TO_SECOND\", "
 		"\"value\": \"P-2DT-3H-4M-5.678S\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -217,6 +225,7 @@ TEST_F(ConvertC2SQL_Interval, CStr2Interval_hour_to_second)
 		"{\"query\": \"CStr2Interval_hour_to_second\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -245,6 +254,7 @@ TEST_F(ConvertC2SQL_Interval, CStr2Interval_hour_to_second_force_alloc)
 		"{\"query\": \"CStr2Interval_hour_to_second_force_alloc\", "
 		"\"params\": [{\"type\": \"INTERVAL_HOUR_TO_SECOND\", "
 		"\"value\": \"PT3H4M5.678S\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -273,6 +283,7 @@ TEST_F(ConvertC2SQL_Interval, Interval2Interval_year_to_month)
 		"{\"query\": \"Interval2Interval_year_to_month\", "
 		"\"params\": [{\"type\": \"INTERVAL_YEAR_TO_MONTH\", "
 		"\"value\": \"P-12Y-11M\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -301,6 +312,7 @@ TEST_F(ConvertC2SQL_Interval, Interval_binary2Interval_year_to_month)
 		"{\"query\": \"Interval_binary2Interval_year_to_month\", "
 		"\"params\": [{\"type\": \"INTERVAL_YEAR_TO_MONTH\", "
 		"\"value\": \"P-12Y-11M\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);

--- a/test/test_conversion_c2sql_numeric.cc
+++ b/test/test_conversion_c2sql_numeric.cc
@@ -38,6 +38,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Short2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Short2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -93,6 +94,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -133,6 +135,7 @@ TEST_F(ConvertC2SQL_Numeric, CStr_Float2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"CStr_Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775806.12345}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -155,6 +158,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Byte2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Byte2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -178,6 +182,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -12345678901234567890.123456789}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -201,6 +206,7 @@ TEST_F(ConvertC2SQL_Numeric, WStr_Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"WStr_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -12345678901234567890.123456789}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -239,6 +245,7 @@ TEST_F(ConvertC2SQL_Numeric, Short2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -12345}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -262,6 +269,7 @@ TEST_F(ConvertC2SQL_Numeric, LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -302,6 +310,7 @@ TEST_F(ConvertC2SQL_Numeric, Float2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Float2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9.2233720368548e+18}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -324,6 +333,7 @@ TEST_F(ConvertC2SQL_Numeric, Byte2Integer)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Byte2Integer\", "
 		"\"params\": [{\"type\": \"INTEGER\", \"value\": -128}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -347,6 +357,7 @@ TEST_F(ConvertC2SQL_Numeric, Double2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -1.23456789e+19}], " /* def prec is 8 */
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -370,6 +381,7 @@ TEST_F(ConvertC2SQL_Numeric, Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -1.234567890123456717e+19}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -410,6 +422,7 @@ TEST_F(ConvertC2SQL_Numeric, Bin_LLong2Long)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_LLong2Long\", "
 		"\"params\": [{\"type\": \"LONG\", "
 		"\"value\": 9223372036854775807}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -451,6 +464,7 @@ TEST_F(ConvertC2SQL_Numeric, Bin_Double2SFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bin_Double2SFloat\", "
 		"\"params\": [{\"type\": \"SCALED_FLOAT\", "
 		"\"value\": -1.234567890123456717e+19}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -479,6 +493,7 @@ TEST_F(ConvertC2SQL_Numeric, Numeric2HFloat)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Numeric2HFloat\", "
 		"\"params\": [{\"type\": \"HALF_FLOAT\", "
 		"\"value\": -2.5212e+01}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -89,6 +89,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_16)
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_16\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -113,6 +114,7 @@ TEST_F(ConvertC2SQL_Timestamp, WStr_Timestamp2Timestamp_colsize_19)
 		"{\"query\": \"WStr_Timestamp2Timestamp_colsize_19\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -153,6 +155,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_trim)
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_trim\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.78901Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -177,6 +180,7 @@ TEST_F(ConvertC2SQL_Timestamp, CStr_Timestamp2Timestamp_colsize_decdigits_full)
 		"{\"query\": \"CStr_Timestamp2Timestamp_colsize_decdigits_full\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.7890123Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -208,6 +212,7 @@ TEST_F(ConvertC2SQL_Timestamp, Timestamp2Timestamp_decdigits_7)
 		"{\"query\": \"Timestamp2Timestamp_decdigits_7\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T12:34:56.7890123Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -240,6 +245,7 @@ TEST_F(ConvertC2SQL_Timestamp, Binary2Timestamp_colsize_0)
 		"{\"query\": \"Binary2Timestamp_colsize_0\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T12:34:56Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -268,6 +274,7 @@ TEST_F(ConvertC2SQL_Timestamp, Date2Timestamp)
 		"{\"query\": \"Date2Timestamp\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2345-01-23T00:00:00Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -298,6 +305,10 @@ class ConvertC2SQL_Timestamp_TZ : public ConvertC2SQL_Timestamp
 		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
 		ASSERT_EQ(putenv("TZ=NPT-5:45NTP"), 0);
 		tzset();
+
+		/* The 'time_zone' param is computed once, at library load -> need to
+		 * recompute after setting the TZ. */
+		ASSERT_TRUE(queries_init());
 	}
 
 	void TearDown() override
@@ -324,6 +335,7 @@ TEST_F(ConvertC2SQL_Timestamp_TZ, WStr_iso8601_Timestamp2Timestamp_colsize_16)
 		"{\"query\": \"WStr_iso8601_Timestamp2Timestamp_colsize_16\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"+05:45\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -347,6 +359,7 @@ TEST_F(ConvertC2SQL_Timestamp_TZ, WStr_iso8601_Timestamp2Timestamp_sz23_dd4)
 		"{\"query\": \"WStr_iso8601_Timestamp2Timestamp_sz23_dd4\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.789Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"+05:45\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -370,6 +383,7 @@ TEST_F(ConvertC2SQL_Timestamp_TZ, WStr_iso8601_Timestamp2Timestamp_decdig4)
 		"{\"query\": \"WStr_iso8601_Timestamp2Timestamp_decdig4\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"1234-12-23T12:34:56.7890Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"+05:45\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -393,6 +407,7 @@ TEST_F(ConvertC2SQL_Timestamp_TZ, WStr_SQL_Timestamp_local2Timestamp)
 		"{\"query\": \"WStr_SQL_Timestamp_local2Timestamp\", "
 		"\"params\": [{\"type\": \"DATETIME\", "
 		"\"value\": \"2000-12-23T12:00:56.7890Z\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"+05:45\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);

--- a/test/test_conversion_c2sql_varchar.cc
+++ b/test/test_conversion_c2sql_varchar.cc
@@ -40,6 +40,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_empty)
 		"{\"query\": \"CStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -64,6 +65,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_empty)
 		"{\"query\": \"WStr2Varchar_empty\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -88,6 +90,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi)
 		"{\"query\": \"WStr2Varchar_ansi\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"0123abcABC\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -112,6 +115,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar)
 		"{\"query\": \"CStr2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"0123abcABC\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -136,6 +140,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi_jsonescape)
 		"{\"query\": \"WStr2Varchar_ansi_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -160,6 +165,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape)
 		"{\"query\": \"CStr2Varchar_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -184,6 +190,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_jsonescape)
 		"{\"query\": \"WStr2Varchar_u8_jsonescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -208,6 +215,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape)
 		"{\"query\": \"WStr2Varchar_u8_fullescape\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -230,6 +238,7 @@ TEST_F(ConvertC2SQL_Varchar, Short2Varchar)
 
 	cstr_st expect = CSTR_INIT("{\"query\": \"Short2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", \"value\": \"-12345\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -253,6 +262,7 @@ TEST_F(ConvertC2SQL_Varchar, Bigint2Varchar)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Bigint2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"9223372036854775807\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);
@@ -293,6 +303,7 @@ TEST_F(ConvertC2SQL_Varchar, Double2Varchar)
 	cstr_st expect = CSTR_INIT("{\"query\": \"Double2Varchar\", "
 		"\"params\": [{\"type\": \"KEYWORD\", "
 		"\"value\": \"1.2000e+00\"}], "
+		"\"field_multi_value_leniency\": true, \"time_zone\": \"Z\", "
 		"\"mode\": \"ODBC\", " CLIENT_ID "}");
 
 	ASSERT_CSTREQ(buff, expect);

--- a/test/test_conversion_sql2c_floats.cc
+++ b/test/test_conversion_sql2c_floats.cc
@@ -29,7 +29,7 @@ TEST_F(ConvertSQL2C_Floats, ScaledFloat2Char_scale_default) {
 #define SQL_VAL "0.98765432100123456789" //20 fractional digits
 #define SQL "CAST(" SQL_VAL " AS SCALED_FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"scaled_float\"}\
@@ -39,18 +39,18 @@ TEST_F(ConvertSQL2C_Floats, ScaledFloat2Char_scale_default) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR buff[sizeof(SQL_VAL)];
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR buff[sizeof(SQL_VAL)];
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len , /*0.*/2 + /* max ES/SQL double scale */19);
-  //std::cerr << buff << std::endl;
-  EXPECT_EQ(memcmp(buff, SQL_VAL, /*0.*/2+/*dbl precision*/15), 0);
+	EXPECT_EQ(ind_len , /*0.*/2 + /* max ES/SQL double scale */19);
+	//std::cerr << buff << std::endl;
+	EXPECT_EQ(memcmp(buff, SQL_VAL, /*0.*/2+/*dbl precision*/15), 0);
 }
 
 
@@ -61,7 +61,7 @@ TEST_F(ConvertSQL2C_Floats, Float2Char_scale_default) {
 #define SQL_VAL "0.98765432109876543219" //20 fractional digits
 #define SQL "CAST(" SQL_VAL " AS FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"float\"}\
@@ -71,17 +71,17 @@ TEST_F(ConvertSQL2C_Floats, Float2Char_scale_default) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR buff[sizeof(SQL_VAL)];
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR buff[sizeof(SQL_VAL)];
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len , /*0.*/2 + /* max ES/SQL double scale */7);
-  EXPECT_EQ(memcmp(buff, SQL_VAL, /*0.*/2+/*float precision*/7), 0);
+	EXPECT_EQ(ind_len , /*0.*/2 + /* max ES/SQL double scale */7);
+	EXPECT_EQ(memcmp(buff, SQL_VAL, /*0.*/2+/*float precision*/7), 0);
 }
 
 
@@ -92,7 +92,7 @@ TEST_F(ConvertSQL2C_Floats, Float2WChar) {
 #define SQL_VAL "-128.998"
 #define SQL "CAST(" SQL_VAL " AS FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"float\"}\
@@ -102,18 +102,18 @@ TEST_F(ConvertSQL2C_Floats, Float2WChar) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLWCHAR wbuff[sizeof(SQL_VAL)];
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_WCHAR, &wbuff, sizeof(wbuff),
-      &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLWCHAR wbuff[sizeof(SQL_VAL)];
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_WCHAR, &wbuff, sizeof(wbuff),
+			&ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len / sizeof(*wbuff), /*-128.*/5 + /*ES/SQL float scale*/7);
-  EXPECT_EQ(wmemcmp(wbuff, MK_WPTR(SQL_VAL), sizeof(SQL_VAL)-/*0*/1), 0);
+	EXPECT_EQ(ind_len / sizeof(*wbuff), /*-128.*/5 + /*ES/SQL float scale*/7);
+	EXPECT_EQ(wmemcmp(wbuff, MK_WPTR(SQL_VAL), sizeof(SQL_VAL)-/*0*/1), 0);
 }
 
 
@@ -134,20 +134,20 @@ TEST_F(ConvertSQL2C_Floats, Float2Char) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR buff[sizeof(SQL_VAL)];
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR buff[sizeof(SQL_VAL)];
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, &buff, sizeof(buff), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  // GE here, since the default scale is high, so more digits would be avail
-  EXPECT_GE(ind_len / sizeof(*buff), sizeof(SQL_VAL) - /*\0*/1);
-  double sql_val = atof((char *)SQL_VAL);
-  double buff2dbl = atof((char *)buff);
-  EXPECT_LE(fabs(sql_val - buff2dbl), .001);
+	// GE here, since the default scale is high, so more digits would be avail
+	EXPECT_GE(ind_len / sizeof(*buff), sizeof(SQL_VAL) - /*\0*/1);
+	double sql_val = atof((char *)SQL_VAL);
+	double buff2dbl = atof((char *)buff);
+	EXPECT_LE(fabs(sql_val - buff2dbl), .001);
 }
 
 
@@ -158,7 +158,7 @@ TEST_F(ConvertSQL2C_Floats, Float2WChar_dotzero) {
 #define SQL_VAL "0.0"
 #define SQL "CAST(" SQL_VAL " AS FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"float\"}\
@@ -168,20 +168,20 @@ TEST_F(ConvertSQL2C_Floats, Float2WChar_dotzero) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLWCHAR wbuff[sizeof(SQL_VAL)];
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_WCHAR, &wbuff, sizeof(wbuff),
-      &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLWCHAR wbuff[sizeof(SQL_VAL)];
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_WCHAR, &wbuff, sizeof(wbuff),
+			&ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len / sizeof(*wbuff), /*0.*/2 + /*ES/SQL FLOAT scale*/7);
-  errno = 0;
-  EXPECT_EQ(wcstod(wbuff, NULL), 0);
-  EXPECT_EQ(errno, 0);
+	EXPECT_EQ(ind_len / sizeof(*wbuff), /*0.*/2 + /*ES/SQL FLOAT scale*/7);
+	errno = 0;
+	EXPECT_EQ(wcstod(wbuff, NULL), 0);
+	EXPECT_EQ(errno, 0);
 }
 
 
@@ -204,18 +204,18 @@ TEST_F(ConvertSQL2C_Floats, Float2TinyInt) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLSCHAR val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_TINYINT, &val, sizeof(val),
-      &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLSCHAR val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_TINYINT, &val, sizeof(val),
+			&ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_LE((SQLSCHAR)SQL_RAW, val);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_LE((SQLSCHAR)SQL_RAW, val);
 }
 
 
@@ -228,7 +228,7 @@ TEST_F(ConvertSQL2C_Floats, Float2UShort) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"float\"}\
@@ -238,17 +238,17 @@ TEST_F(ConvertSQL2C_Floats, Float2UShort) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLUSMALLINT val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_USHORT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLUSMALLINT val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_USHORT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_EQ((SQLUSMALLINT)SQL_RAW, val);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_EQ((SQLUSMALLINT)SQL_RAW, val);
 }
 
 
@@ -261,7 +261,7 @@ TEST_F(ConvertSQL2C_Floats, Float2Long) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS FLOAT)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"float\"}\
@@ -271,17 +271,17 @@ TEST_F(ConvertSQL2C_Floats, Float2Long) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLINTEGER val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_LONG, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLINTEGER val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_LONG, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_LE((SQLINTEGER)SQL_RAW, val);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_LE((SQLINTEGER)SQL_RAW, val);
 }
 
 
@@ -294,7 +294,7 @@ TEST_F(ConvertSQL2C_Floats, Double_zero2Float) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"double\"}\
@@ -304,17 +304,17 @@ TEST_F(ConvertSQL2C_Floats, Double_zero2Float) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLREAL val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_FLOAT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLREAL val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_FLOAT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_LE(SQL_RAW, val);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_LE(SQL_RAW, val);
 }
 
 
@@ -327,7 +327,7 @@ TEST_F(ConvertSQL2C_Floats, Double2Float) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"double\"}\
@@ -337,17 +337,17 @@ TEST_F(ConvertSQL2C_Floats, Double2Float) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLREAL val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_FLOAT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLREAL val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_FLOAT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_LE(SQL_RAW, val);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_LE(SQL_RAW, val);
 }
 
 
@@ -360,7 +360,7 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit_fail_22003) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"half_float\"}\
@@ -370,15 +370,15 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit_fail_22003) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_FALSE(SQL_SUCCEEDED(ret));
-  assertState(L"22003");
+	ret = SQLFetch(stmt);
+	ASSERT_FALSE(SQL_SUCCEEDED(ret));
+	assertState(L"22003");
 }
 
 
@@ -391,7 +391,7 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit_truncate_01S07) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"half_float\"}\
@@ -401,16 +401,16 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit_truncate_01S07) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
-  assertState(L"01S07");
-  ASSERT_EQ(val, 1);
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	assertState(L"01S07");
+	ASSERT_EQ(val, 1);
 }
 
 
@@ -423,7 +423,7 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"half_float\"}\
@@ -433,16 +433,16 @@ TEST_F(ConvertSQL2C_Floats, HalfFloat2Bit) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLCHAR val;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLCHAR val;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_BIT, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
-  assertState(NULL);
-  ASSERT_EQ(val, 1);
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	assertState(NULL);
+	ASSERT_EQ(val, 1);
 }
 
 
@@ -458,7 +458,7 @@ TEST_F(ConvertSQL2C_Floats, Double2Numeric) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"double\"}\
@@ -468,37 +468,37 @@ TEST_F(ConvertSQL2C_Floats, Double2Numeric) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  //
-  //set scale
-  //
-  SQLHDESC ard;
-  ret = SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	//
+	//set scale
+	//
+	SQLHDESC ard;
+	ret = SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLSetDescField(ard, 1, SQL_DESC_TYPE, (SQLPOINTER)SQL_C_NUMERIC, 0);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
-  ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)SQL_PREC, 0);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
-  ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)SQL_SCALE, 0);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
-  ret = SQLSetDescField(ard, /*col#*/1, SQL_DESC_OCTET_LENGTH_PTR,
-      (SQLPOINTER)&ind_len, 0);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLSetDescField(ard, 1, SQL_DESC_TYPE, (SQLPOINTER)SQL_C_NUMERIC, 0);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)SQL_PREC, 0);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)SQL_SCALE, 0);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLSetDescField(ard, /*col#*/1, SQL_DESC_OCTET_LENGTH_PTR,
+			(SQLPOINTER)&ind_len, 0);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  SQL_NUMERIC_STRUCT val;
-  ret = SQLSetDescField(ard, 1, SQL_DESC_DATA_PTR, (SQLPOINTER) &val, 0);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQL_NUMERIC_STRUCT val;
+	ret = SQLSetDescField(ard, 1, SQL_DESC_DATA_PTR, (SQLPOINTER) &val, 0);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_EQ(val.sign, 1);
-  EXPECT_EQ(val.scale, SQL_SCALE);
-  EXPECT_EQ(val.precision, SQL_PREC);
-  EXPECT_EQ(memcmp(val.val, "|b", 2), 0);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_EQ(val.sign, 1);
+	EXPECT_EQ(val.scale, SQL_SCALE);
+	EXPECT_EQ(val.precision, SQL_PREC);
+	EXPECT_EQ(memcmp(val.val, "|b", 2), 0);
 }
 
 
@@ -511,7 +511,7 @@ TEST_F(ConvertSQL2C_Floats, Double2Binary) {
 #define SQL_VAL STR(SQL_RAW)
 #define SQL "CAST(" SQL_VAL " AS DOUBLE)"
 
-  const char json_answer[] = "\
+	const char json_answer[] = "\
 {\
   \"columns\": [\
     {\"name\": \"" SQL "\", \"type\": \"double\"}\
@@ -521,17 +521,17 @@ TEST_F(ConvertSQL2C_Floats, Double2Binary) {
   ]\
 }\
 ";
-  prepareStatement(json_answer);
+	prepareStatement(json_answer);
 
-  SQLDOUBLE val = 0;
-  ret = SQLBindCol(stmt, /*col#*/1, SQL_C_DOUBLE, &val, sizeof(val), &ind_len);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	SQLDOUBLE val = 0;
+	ret = SQLBindCol(stmt, /*col#*/1, SQL_C_DOUBLE, &val, sizeof(val), &ind_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  ret = SQLFetch(stmt);
-  ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-  EXPECT_EQ(ind_len, sizeof(val));
-  EXPECT_EQ(val, SQL_RAW);
+	EXPECT_EQ(ind_len, sizeof(val));
+	EXPECT_EQ(val, SQL_RAW);
 }
 
 


### PR DESCRIPTION
This PR adds the DSN configuration and SQL request parameters for:
* the timezone the request should be executed under (relevant for histograms and other time functions);
* the way multi-value fields should be handled by the server.

It also has the integration testing attempt multiple times to enable the trial license and not give up on first error code returned by the server.