### PR TITLE
Fail quickly if hostname starts with a HTTP(S) scheme

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1030,6 +1030,9 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 			prefix = attrs->server;
 			prefix.cnt = http_prefix.cnt;
 			if (! EQ_CASE_WSTR(&prefix, &http_prefix)) {
+				if (attrs->server.cnt < https_prefix.cnt) {
+					break;
+				}
 				prefix.cnt = https_prefix.cnt;
 				if (! EQ_CASE_WSTR(&prefix, &https_prefix)) {
 					break;


### PR DESCRIPTION
This PR checks if the Hostname (`server`) configuration begins with `http(s)://` and return a specific error
message if so, to help with a more common config error.

Closes #135 