### PR TITLE
Apply DST

### DIFF
--- a/driver/convert.c
+++ b/driver/convert.c
@@ -96,7 +96,7 @@ static BOOL compat_matrix[ESSQL_NORM_RANGE][ESSQL_C_NORM_RANGE] = {FALSE};
  * https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/converting-data-from-c-to-sql-data-types
  * "from" and "to" nameing attributes below correspond to items in the
  * vertical and horizontal lists, respectively. */
-void TEST_API convert_init()
+void convert_init()
 {
 	SQLSMALLINT i, j, sql, csql, lim_i, lim_j;
 	/*INDENT-OFF*/

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -11,21 +11,11 @@
 
 #include <timestamp.h>
 
-#include "handles.h"
+#include "convert.h"
 
 #define JSON_VAL_NULL			"null"
 #define JSON_VAL_TRUE			"true"
 #define JSON_VAL_FALSE			"false"
-
-#define TM_TO_TIMESTAMP_STRUCT(_tmp/*src*/, _tsp/*dst*/) \
-	do { \
-		(_tsp)->year = (_tmp)->tm_year + 1900; \
-		(_tsp)->month = (_tmp)->tm_mon + 1; \
-		(_tsp)->day = (_tmp)->tm_mday; \
-		(_tsp)->hour = (_tmp)->tm_hour; \
-		(_tsp)->minute = (_tmp)->tm_min; \
-		(_tsp)->second = (_tmp)->tm_sec; \
-	} while (0)
 
 #ifdef _WIN32
 #	ifndef _USE_32BIT_TIME_T
@@ -37,6 +27,9 @@
 #	error "platform not supported"
 #endif /* _WIN32 */
 #define MKTIME_FAIL_MSG "Outside of the " MKTIME_YEAR_RANGE "year range?"
+
+/* see "recent" meaning in parse_date_time_ts() */
+static thread_local SQLCHAR recent_date[] = "1970-01-01";
 
 /* For fixed size (destination) types, the target buffer can't be NULL. */
 #define REJECT_IF_NULL_DEST_BUFF(_s/*tatement*/, _p/*ointer*/) \
@@ -1540,6 +1533,8 @@ static inline SQLRETURN wstr_to_wstr(esodbc_rec_st *arec, esodbc_rec_st *irec,
 }
 
 /* Parses an ISO8601 timestamp and returns the result into a TIMESTAMP_STRUCT.
+ * The time is adjusted to UTC timezone or kept "local", depending on 'to_utc'
+ * value (TIMESTAMP_STRUCT lacks any timezone indicator).
  * Returns:
  * - SQL_STATE_0000 for success,
  * - _22007 if the string is not a timestamp and
@@ -1551,7 +1546,8 @@ static SQLRETURN parse_iso8601_timestamp(esodbc_stmt_st *stmt, xstr_st *xstr,
 	char buff[ISO8601_TIMESTAMP_MAX_LEN + /*\0*/1];
 	cstr_st ts_str;
 	timestamp_t tsp;
-	struct tm tm;
+	struct tm tm, *tmp;
+	time_t utc;
 
 	if (xstr->wide) {
 		DBGH(stmt, "parsing `" LWPDL "` as ISO timestamp.", LWSTR(&xstr->w));
@@ -1582,21 +1578,19 @@ static SQLRETURN parse_iso8601_timestamp(esodbc_stmt_st *stmt, xstr_st *xstr,
 	}
 
 	if (! to_utc) {
-		/* apply local offset */
-		tm.tm_sec -= _tz_dst_offt; /* serialize_statement() will update it */
-		tm.tm_isdst = -1; /* let the system determine the daylight saving */
-		/* rebalance member values */
-		if (mktime(&tm) == (time_t)-1) {
-			ERRH(stmt, "failed to adjust timestamp `" LCPDL "` by TZ (%ld). "
-				MKTIME_FAIL_MSG, LCSTR(&ts_str), _tz_dst_offt);
-			RET_HDIAG(stmt, SQL_STATE_22008, "Timestamp timezone adjustment "
-				"failed. " MKTIME_FAIL_MSG, 0);
+		/* convert UTC to localtime */
+		if ((utc = timegm(&tm)) == (time_t)-1 || ! (tmp = localtime(&utc))) {
+			ERRNH(stmt, "failed to convert timestamp `" LCPDL "` to UTC. "
+				MKTIME_FAIL_MSG, LCSTR(&ts_str));
+			RET_HDIAG(stmt, SQL_STATE_22008, "Timestamp conversion failed. "
+				MKTIME_FAIL_MSG, 0);
+		} else {
+			tm = *tmp;
 		}
 	}
 
-	TM_TO_TIMESTAMP_STRUCT(&tm, tss);
 	/* "the fraction field is the number of billionths of a second" */
-	tss->fraction = tsp.nsec;
+	TM_TO_TIMESTAMP_STRUCT(&tm, tss, tsp.nsec);
 
 	DBGH(stmt, "parsed %s timestamp: %04d-%02d-%02d %02d:%02d:%02d.%u.",
 		to_utc ? "UTC" : "local", tss->year, tss->month, tss->day,
@@ -1605,23 +1599,64 @@ static SQLRETURN parse_iso8601_timestamp(esodbc_stmt_st *stmt, xstr_st *xstr,
 	return SQL_SUCCESS;
 }
 
+BOOL update_dst_date(struct tm *now)
+{
+	int n;
+
+	assert(sizeof(SQLCHAR) == sizeof(char));
+	assert(sizeof(recent_date) - /*\0*/1 == DATE_TEMPLATE_LEN);
+	n = snprintf(recent_date, DATE_TEMPLATE_LEN + 1, "%04d-%02d-%02d",
+			now->tm_year + 1900, now->tm_mon + 1, now->tm_mday);
+	if (n <= 0 || DATE_TEMPLATE_LEN < n) {
+		ERRN("failed to update the DST date.");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static SQLRETURN tss_local_to_utc(esodbc_stmt_st *stmt, TIMESTAMP_STRUCT *tss)
+{
+	struct tm *tmp, tm;
+	time_t utc;
+
+	TIMESTAMP_STRUCT_TO_TM(tss, &tm);
+	tm.tm_isdst = -1;
+	if (((utc = mktime(&tm)) == (time_t)-1) || (! (tmp = gmtime(&utc)))) {
+		ERRNH(stmt, "failed to convert local timestamp "
+			"%04hd-%02hu-%02hu %02hu:%02hu:%02hu..%lu to UTC. "
+			MKTIME_FAIL_MSG, tss->year, tss->month, tss->day,
+			tss->hour, tss->minute, tss->second, tss->fraction);
+		RET_HDIAG(stmt, SQL_STATE_22008, "Timestamp timezone adjustment "
+			"failed. " MKTIME_FAIL_MSG, errno);
+	}
+	TM_TO_TIMESTAMP_STRUCT(tmp, tss, tss->fraction);
+
+	DBGH(stmt, "UTC: `%04hd-%02hu-%02hu %02hu:%02hu:%02hu..%lu`.",
+		tss->year, tss->month, tss->day,
+		tss->hour, tss->minute, tss->second, tss->fraction);
+	return SQL_SUCCESS;
+}
 
 /* Analyzes the received string as time/date/timestamp(timedate) and parses it
  * into received 'tss' struct, indicating detected format in 'format'. */
 static SQLRETURN parse_date_time_ts(esodbc_stmt_st *stmt, xstr_st *xstr,
 	BOOL sql2c, TIMESTAMP_STRUCT *tss, SQLSMALLINT *format)
 {
-	esodbc_dbc_st *dbc;
 	SQLRETURN ret;
-	/* template buffer: date or time values will be copied in place and
-	 * evaluated as a timestamp (needs to be valid) */
-	SQLCHAR templ[] = "0001-01-01T00:00:00.000000000+00:00";
+	/* Template buffer: date or time values will be copied in place and
+	 * evaluated as a timestamp.
+	 * It needs to be a "recent" date, since UTC-local_time conversions will
+	 * need to make use of the correct DST setting.
+	 * "recent": date within the same DST interval with the wall-clock time. */
+	SQLCHAR templ[] = "1970-01-01T00:00:00.000000000+00:00";
+	SQLCHAR sign;
 	/* conversion Wide to C-string buffer */
 	SQLCHAR w2c[ISO8601_TIMESTAMP_MAX_LEN];
 	cstr_st td;/* timedate string */
 	xstr_st xtd;
-	long hours, mins, n;
-	BOOL to_utc;
+	esodbc_dbc_st *dbc = HDRH(stmt)->dbc;
+	BOOL to_utc = sql2c ? (! dbc->apply_tz) : TRUE;
+	BOOL local_to_utc;
 
 	/* W-strings will eventually require convertion to C-string for TS
 	 * conversion => do it now to simplify string analysis */
@@ -1637,60 +1672,63 @@ static SQLRETURN parse_date_time_ts(esodbc_stmt_st *stmt, xstr_st *xstr,
 	if (TIMESTAMP_TEMPLATE_LEN(0) <= td.cnt) {
 		assert(TIMESTAMP_TEMPLATE_LEN(0) < ISO8601_TIMESTAMP_MIN_LEN);
 
-		dbc = HDRH(stmt)->dbc;
+		local_to_utc = FALSE;
 		/* is this a SQL-format timestamp? (vs ISO8601) */
 		if (td.str[DATE_TEMPLATE_LEN] == ' ') { /* vs. 'T' */
 			td.str[DATE_TEMPLATE_LEN] = 'T';
+			td.str[td.cnt ++] = 'Z';
 
-			/* if c2sql, apply_tz will tell if time is UTC already or not */
-			if ((! sql2c) && dbc->apply_tz) {
-				hours = -_tz_dst_offt / 3600;
-				mins = _tz_dst_offt < 0 ? -_tz_dst_offt : _tz_dst_offt;
-				mins = mins % 3600;
-				assert(mins % 60 == 0); /* XXX: TZ spec accepts seconds */
-				mins /= 60;
-				n = snprintf(td.str + td.cnt, /*±00:00\0*/7, "%+03ld:%02ld",
-						hours, mins);
-				if (n <= 0) {
-					ERRNH(stmt, "failed to print TZ+DST offset (%ld).",
-						_tz_dst_offt);
-					RET_HDIAGS(stmt, SQL_STATE_HY000);
-				}
-				td.cnt += (size_t)n;
-			} else {
-				/* TZ not applicable (UTC is used) or it's an ES-originated
-				 * value => assume UTC: the query can construct a SQL
-				 * timestamp that the app then wants translated to timestamp */
-				td.str[td.cnt] = 'Z';
-				td.cnt ++;
-			}
-			DBGH(stmt, "SQL format translated to ISO: [%zu] `" LCPDL "`.",
-				td.cnt, LCSTR(&td));
+			/* If the received string is a local timestamp, it needs to be
+			 * first parsed (possibly as if it were a UTC value already) and
+			 * once that's done and the TSS is available, shifted to the
+			 * actual UTC value. */
+			/* If c2sql, apply_tz will tell if time is local (apply_tz==TRUE)
+			 * or UTC (apply_tz==FALSE);
+			 * If local_to_utc==FALSE: TZ not applicable (UTC is used) or it's
+			 * an ES-originated value (sql2c==TRUE) => assume UTC: the query
+			 * can construct a SQL timestamp (i.e. the result data type is a
+			 * text/KW) that the app then wants translated to a timestamp. */
+			local_to_utc = (! sql2c) && dbc->apply_tz;
+
+			DBGH(stmt, "SQL format translated to ISO: [%zu] `" LCPDL "`. "
+				"Local to UTC: %d.", td.cnt, LCSTR(&td), local_to_utc);
 		} /* else: already in ISO8601 format */
 
 		xtd.c = td;
-		to_utc = sql2c ? (! dbc->apply_tz) : TRUE;
 		ret = parse_iso8601_timestamp(stmt, &xtd, to_utc, tss);
-		if (SQL_SUCCEEDED(ret) && format) {
-			*format = SQL_TYPE_TIMESTAMP;
+		if (SQL_SUCCEEDED(ret)) {
+			if (format) {
+				*format = SQL_TYPE_TIMESTAMP;
+			}
+			if (local_to_utc) {
+				ret = tss_local_to_utc(stmt, tss);
+			}
 		} else {
 			ERRH(stmt, "`" LCPDL "` is not a TIMESTAMP value.", LCSTR(&td));
 		}
 		return ret;
 	}
 
-	/* could this be a TIME value? */
+	/* could this be a TIME value? hh:mm:ss / hh:mm:ssZ / hh:mm:ss+HH:MM */
 	if (TIME_TEMPLATE_LEN(0) <= td.cnt &&
 		td.str[2] == ':' && td.str[5] == ':') {
+		memcpy(templ, recent_date, sizeof(recent_date) - /*\0*/1);
 		/* copy active value in template and parse it as TS */
 		/* copy is safe: cnt <= [time template] < [templ] */
 		memcpy(templ + DATE_TEMPLATE_LEN + /*'T'*/1, td.str, td.cnt);
-		/* there could be a varying number of fractional digits */
-		templ[DATE_TEMPLATE_LEN + /*'T'*/1 + td.cnt] = 'Z';
-		xtd.c.cnt = td.cnt + DATE_TEMPLATE_LEN + /*'T'*/1 + /*Z*/1;
+		assert(sizeof("+HH:MM") - 1 < TIME_TEMPLATE_LEN(0));
+		sign = td.str[td.cnt - (sizeof("+HH:MM") - /*\0*/1)];
+		if (td.str[td.cnt - 1] != 'Z' && /* not a Zulu time */
+			(sign != '+' && sign != '-')) { /* not in hh:mm:ss±HH:MM format */
+			/* there could be a varying number of fractional digits */
+			templ[DATE_TEMPLATE_LEN + /*'T'*/1 + td.cnt] = 'Z';
+			xtd.c.cnt = DATE_TEMPLATE_LEN + /*'T'*/1 + td.cnt + /*Z*/1;
+		} else {
+			xtd.c.cnt = DATE_TEMPLATE_LEN + /*'T'*/1 + td.cnt;
+		}
 		xtd.c.str = templ;
 
-		ret = parse_iso8601_timestamp(stmt, &xtd, /*to UTC*/TRUE, tss);
+		ret = parse_iso8601_timestamp(stmt, &xtd, to_utc, tss);
 		if (SQL_SUCCEEDED(ret)) {
 			tss->year = tss->month = tss->day = 0;
 			if (format) {
@@ -1702,7 +1740,7 @@ static SQLRETURN parse_date_time_ts(esodbc_stmt_st *stmt, xstr_st *xstr,
 		return ret;
 	}
 
-	/* could this be a DATE value? */
+	/* could this be a DATE value? YYYY-MM-DD */
 	if (DATE_TEMPLATE_LEN <= td.cnt && td.str[4] == '-' && td.str[7] == '-') {
 		/* copy active value in template and parse it as TS */
 		/* copy is safe: cnt <= [time template] < [templ] */
@@ -2933,10 +2971,10 @@ static int print_timestamp(TIMESTAMP_STRUCT *tss, BOOL iso8601,
 {
 	int n;
 	size_t lim;
-	wchar_t *fmt;
+	const wchar_t *fmt;
 	SQLUINTEGER nsec; /* "fraction" */
-#	define FMT_TIMESTAMP_MILLIS		"%04d-%02d-%02d %02d:%02d:%02d.%lu"
-#	define FMT_TIMESTAMP_NOMILLIS	"%04d-%02d-%02d %02d:%02d:%02d"
+	const static wchar_t *fmt_millis = L"%04d-%02d-%02d %02d:%02d:%02d.%.*lu";
+	const static wchar_t *fmt_nomillis = L"%04d-%02d-%02d %02d:%02d:%02d";
 
 	/* see c2sql_timestamp() for an explanation of these values */
 	assert((! colsize) || (colsize == 16 || colsize == 19 || 20 < colsize));
@@ -2944,11 +2982,12 @@ static int print_timestamp(TIMESTAMP_STRUCT *tss, BOOL iso8601,
 
 	nsec = tss->fraction;
 	if (0 < decdigits) {
-		fmt = MK_WPTR(FMT_TIMESTAMP_MILLIS);
 		assert(decdigits <= ESODBC_MAX_SEC_PRECISION);
 		nsec /= (SQLUINTEGER)pow10(ESODBC_MAX_SEC_PRECISION - decdigits);
+		/* only print millis if they are non-null */
+		fmt = nsec ? fmt_millis : fmt_nomillis;
 	} else {
-		fmt = MK_WPTR(FMT_TIMESTAMP_NOMILLIS);
+		fmt = fmt_nomillis;
 	}
 	/* swprintf and now (=14.15.26706) also _snwprintf() both fail instead of
 	 * truncating, despite the documentation indicating otherwise => give full
@@ -2957,7 +2996,7 @@ static int print_timestamp(TIMESTAMP_STRUCT *tss, BOOL iso8601,
 			fmt, tss->year, tss->month, tss->day,
 			tss->hour, tss->minute, tss->second,
 			/* fraction is always provided, but only printed if 'decdigits' */
-			nsec);
+			decdigits, nsec);
 	if ((int)lim < n) {
 		n = (int)lim;
 	}
@@ -2971,14 +3010,12 @@ static int print_timestamp(TIMESTAMP_STRUCT *tss, BOOL iso8601,
 			dest[n] = L'Z';
 			n ++;
 		}
-		DBG("printed UTC %s timestamp: [%d] `" LWPDL "`.",
-			iso8601 ? "ISO8601" : "SQL", n, n, dest);
+		DBG("printed UTC %s timestamp (colsz: %lu, decdig: %hd): "
+			"[%d] `" LWPDL "`.", iso8601 ? "ISO8601" : "SQL",
+			(SQLUINTEGER)colsize, decdigits, n, n, dest);
 	}
 
-
 	return n;
-#	undef FMT_TIMESTAMP_MILLIS
-#	undef FMT_TIMESTAMP_NOMILLIS
 }
 
 /* transform an ISO8601 timestamp str. to SQL/ODBC timestamp str. */
@@ -3955,6 +3992,7 @@ static SQLRETURN struct_to_iso8601_timestamp(esodbc_stmt_st *stmt,
 	DATE_STRUCT *ds;
 	int n;
 	size_t osize;
+	SQLRETURN ret;
 
 	switch (ctype) {
 		case SQL_C_TYPE_DATE:
@@ -3986,6 +4024,16 @@ static SQLRETURN struct_to_iso8601_timestamp(esodbc_stmt_st *stmt,
 		default:
 			BUGH(stmt, "unexpected SQL C type %hd.", ctype);
 			RET_HDIAG(stmt, SQL_STATE_HY000, "param conversion bug", 0);
+	}
+
+	if (HDRH(stmt)->dbc->apply_tz) {
+		/* used for C2SQL conversions only: localtime to UTC */
+		buff = *tss;
+		ret = tss_local_to_utc(stmt, &buff);
+		if (! SQL_SUCCEEDED(ret)) {
+			return ret;
+		}
+		tss = &buff;
 	}
 
 	n = print_timestamp(tss, /*ISO?*/TRUE, colsize, decdigits, dest);

--- a/driver/convert.h
+++ b/driver/convert.h
@@ -9,7 +9,7 @@
 #include "error.h"
 #include "handles.h"
 
-void convert_init();
+BOOL TEST_API convert_init();
 
 SQLRETURN set_param_decdigits(esodbc_rec_st *irec,
 	SQLUSMALLINT param_no, SQLSMALLINT decdigits);

--- a/driver/convert.h
+++ b/driver/convert.h
@@ -23,6 +23,7 @@ inline void *deferred_address(SQLSMALLINT field_id, size_t pos,
 
 SQLRETURN convertability_check(esodbc_stmt_st *stmt, SQLINTEGER idx,
 	int *conv_code);
+BOOL update_dst_date(struct tm *now);
 
 /*
  * SQL -> C SQL
@@ -37,7 +38,7 @@ SQLRETURN sql2c_double(esodbc_rec_st *arec, esodbc_rec_st *irec,
 /*
  * SQL C -> SQL
  */
-inline SQLRETURN c2sql_null(esodbc_rec_st *arec,
+SQLRETURN c2sql_null(esodbc_rec_st *arec,
 	esodbc_rec_st *irec, char *dest, size_t *len);
 SQLRETURN c2sql_boolean(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	SQLULEN pos, char *dest, size_t *len);
@@ -50,5 +51,26 @@ SQLRETURN c2sql_timestamp(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	SQLULEN pos, char *dest, size_t *len);
 SQLRETURN c2sql_interval(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	SQLULEN pos, char *dest, size_t *len);
+
+#define TM_TO_TIMESTAMP_STRUCT(_tmp/*src*/, _tsp/*dst*/, frac) \
+	do { \
+		(_tsp)->year = (_tmp)->tm_year + 1900; \
+		(_tsp)->month = (_tmp)->tm_mon + 1; \
+		(_tsp)->day = (_tmp)->tm_mday; \
+		(_tsp)->hour = (_tmp)->tm_hour; \
+		(_tsp)->minute = (_tmp)->tm_min; \
+		(_tsp)->second = (_tmp)->tm_sec; \
+		(_tsp)->fraction = frac; \
+	} while (0)
+
+#define TIMESTAMP_STRUCT_TO_TM(_tsp/*src*/, _tmp/*dst*/) \
+	do { \
+		(_tmp)->tm_year = (_tsp)->year - 1900; \
+		(_tmp)->tm_mon = (_tsp)->month - 1; \
+		(_tmp)->tm_mday = (_tsp)->day; \
+		(_tmp)->tm_hour = (_tsp)->hour; \
+		(_tmp)->tm_min = (_tsp)->minute; \
+		(_tmp)->tm_sec = (_tsp)->second; \
+	} while (0)
 
 #endif /* __CONVERT_H__ */

--- a/driver/convert.h
+++ b/driver/convert.h
@@ -9,7 +9,7 @@
 #include "error.h"
 #include "handles.h"
 
-BOOL TEST_API convert_init();
+void TEST_API convert_init();
 
 SQLRETURN set_param_decdigits(esodbc_rec_st *irec,
 	SQLUSMALLINT param_no, SQLSMALLINT decdigits);

--- a/driver/convert.h
+++ b/driver/convert.h
@@ -9,7 +9,7 @@
 #include "error.h"
 #include "handles.h"
 
-void TEST_API convert_init();
+void convert_init();
 
 SQLRETURN set_param_decdigits(esodbc_rec_st *irec,
 	SQLUSMALLINT param_no, SQLSMALLINT decdigits);

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -30,9 +30,7 @@ static BOOL driver_init()
 		return FALSE;
 	}
 	INFO("initializing driver.");
-	if (! convert_init()) {
-		return FALSE;
-	}
+	convert_init();
 	if (! connect_init()) {
 		return FALSE;
 	}

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -30,7 +30,9 @@ static BOOL driver_init()
 		return FALSE;
 	}
 	INFO("initializing driver.");
-	convert_init();
+	if (! convert_init()) {
+		return FALSE;
+	}
 	if (! connect_init()) {
 		return FALSE;
 	}

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -9,7 +9,7 @@
 #include "error.h"
 #include "handles.h"
 
-BOOL TEST_API queries_init();
+BOOL queries_init();
 void clear_resultset(esodbc_stmt_st *stmt, BOOL on_close);
 SQLRETURN TEST_API attach_answer(esodbc_stmt_st *stmt, char *buff,
 	size_t blen);

--- a/driver/util.c
+++ b/driver/util.c
@@ -8,8 +8,6 @@
 #include <errno.h>
 #include <stdio.h>
 
-#include <time.h>
-
 #include "util.h"
 #include "handles.h"
 #include "error.h"

--- a/driver/util.c
+++ b/driver/util.c
@@ -41,7 +41,7 @@ BOOL update_tz_dst_offset()
 	 * end/start, which should be a safe assumption */
 	tz_dst_offt = gm.tm_yday * 24 * 3600 + gm.tm_hour * 3600 + gm.tm_min * 60;
 	tz_dst_offt -= local.tm_yday * 24 * 3600;
-	tz_dst_offt -=  local.tm_hour * 3600 + local.tm_min * 60;
+	tz_dst_offt -= local.tm_hour * 3600 + local.tm_min * 60;
 
 	if (! tz) {
 		tz = getenv(ESODBC_TZ_ENV_VAR);

--- a/driver/util.h
+++ b/driver/util.h
@@ -156,7 +156,6 @@ void wrtrim_ws(wstr_st *wstr);
  * Returns TRUE if character has been encounter / trimming occured. */
 BOOL wtrim_at(wstr_st *wstr, SQLWCHAR wchar);
 
-BOOL tz_dst_offset(long *offset);
 BOOL wstr2bool(wstr_st *val);
 /* Converts a [cw]str_st to a SQL(U)BIGINT.
  * If !strict, parsing stops at first non-digit char.
@@ -169,6 +168,9 @@ int str2double(void *val, BOOL wide, SQLDOUBLE *dbl, BOOL strict);
 size_t i64tot(int64_t i64, void *buff, BOOL wide);
 size_t ui64tot(uint64_t ui64, void *buff, BOOL wide);
 
+/* total timezone plus daylight saving offset */
+extern long _tz_dst_offt;
+BOOL update_tz_dst_offset();
 
 #ifdef _WIN32
 /*

--- a/driver/util.h
+++ b/driver/util.h
@@ -168,10 +168,6 @@ int str2double(void *val, BOOL wide, SQLDOUBLE *dbl, BOOL strict);
 size_t i64tot(int64_t i64, void *buff, BOOL wide);
 size_t ui64tot(uint64_t ui64, void *buff, BOOL wide);
 
-/* total timezone plus daylight saving offset */
-extern long _tz_dst_offt;
-BOOL update_tz_dst_offset();
-
 #ifdef _WIN32
 /*
  * "[D]oes not null-terminate an output string if the input string length is
@@ -203,6 +199,12 @@ typedef SRWLOCK esodbc_mutex_lt;
 #define ESODBC_MUX_LOCK(_m)		AcquireSRWLockExclusive(_m)
 #define ESODBC_MUX_TRYLOCK(_m)	TryAcquireSRWLockExclusive(_m)
 #define ESODBC_MUX_UNLOCK(_m)	ReleaseSRWLockExclusive(_m)
+
+#if defined(DRIVER_BUILD) && !defined(thread_local)
+#define thread_local __declspec(thread)
+#endif /* DRIVER_BUILD && !thread_local */
+
+#define timegm _mkgmtime
 
 #else /* _WIN32 */
 

--- a/driver/util.h
+++ b/driver/util.h
@@ -156,6 +156,7 @@ void wrtrim_ws(wstr_st *wstr);
  * Returns TRUE if character has been encounter / trimming occured. */
 BOOL wtrim_at(wstr_st *wstr, SQLWCHAR wchar);
 
+BOOL tz_dst_offset(long *offset);
 BOOL wstr2bool(wstr_st *val);
 /* Converts a [cw]str_st to a SQL(U)BIGINT.
  * If !strict, parsing stops at first non-digit char.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,7 @@ file(GLOB TEST_CASES LIST_DIRECTORIES false
 message("Driver test cases: ${TEST_CASES}")
 
 set(EXTRA_SRC connected_dbc.cc)
+aux_source_directory(${CTIMESTAMP_PATH_SRC}/ CTS_SRC)
 
 # copy DLLs linked (later) against, so that test exes can load them
 file(TO_NATIVE_PATH
@@ -108,7 +109,14 @@ add_custom_target(install_shared
 
 foreach (TSRC ${TEST_CASES})
 	string(REPLACE ".cxx" "" TBIN ${TSRC})
-	add_executable(${TBIN} ${TSRC} ${EXTRA_SRC})
+
+	if (${TBIN} MATCHES ".*test_conversion_c2sql_timestamp.*")
+		# this one test requires the c-timestamp lib
+		add_executable(${TBIN} ${TSRC} ${EXTRA_SRC} ${CTS_SRC})
+	else ()
+		add_executable(${TBIN} ${TSRC} ${EXTRA_SRC})
+	endif ()
+
 	set_target_properties(${TBIN} PROPERTIES COMPILE_FLAGS ${CMAKE_C_FLAGS})
 	target_link_libraries(${TBIN} ${DRV_NAME} ${GTEST_LIB} ${GTEST_MAIN_LIB})
 	add_dependencies(${TBIN} install_shared)

--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <sqlext.h>
 
 #include "queries.h"
+#include "convert.h"
 } // extern C
 
 #if defined(_WIN32) || defined (WIN32)

--- a/test/integration/install.py
+++ b/test/integration/install.py
@@ -17,7 +17,7 @@ from elasticsearch import Elasticsearch
 
 DRIVER_BASE_NAME = "Elasticsearch ODBC Driver"
 # Uninstallation can take quite a long time (over 10s)
-INSTALLATION_TIMEOUT = 30
+INSTALLATION_TIMEOUT = 60
 
 class Installer(object):
 	_driver_path = None

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -303,13 +303,12 @@ class ConvertC2SQL_Timestamp_TZ : public ConvertC2SQL_Timestamp
 	void SetUp() override
 	{
 		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
-		ASSERT_EQ(putenv("TZ=NPT-5:45NTP"), 0);
+		ASSERT_EQ(putenv("TZ=NPT-5:45"), 0);
 		tzset();
 
 		/* The 'time_zone' & co. params are computed once, at library load ->
 		 * need to recompute after setting the TZ. */
 		ASSERT_TRUE(queries_init());
-		ASSERT_TRUE(convert_init());
 	}
 
 	void TearDown() override

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -306,9 +306,10 @@ class ConvertC2SQL_Timestamp_TZ : public ConvertC2SQL_Timestamp
 		ASSERT_EQ(putenv("TZ=NPT-5:45NTP"), 0);
 		tzset();
 
-		/* The 'time_zone' param is computed once, at library load -> need to
-		 * recompute after setting the TZ. */
+		/* The 'time_zone' & co. params are computed once, at library load ->
+		 * need to recompute after setting the TZ. */
 		ASSERT_TRUE(queries_init());
+		ASSERT_TRUE(convert_init());
 	}
 
 	void TearDown() override

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -437,14 +437,14 @@ class ConvertC2SQL_Timestamp_DST : public ConvertC2SQL_Timestamp
 		/* see note in ConvertSQL2C_Timestamp_DST's constructor in
 		 * test_conversion_sql2c_timestamp.cc */
 
-		/* 2000-01-01 12:34:56.789 */
+		/* 2000-01-01 12:00:00.120 */
 		no_dst_local.year = 2000;
 		no_dst_local.month = 1; /* Jan */
 		no_dst_local.day = 1;
 		no_dst_local.hour = 12;
 		no_dst_local.fraction = 120000000;
 
-		/* 2000-05-01 12:34:56.789 */
+		/* 2000-05-01 12:00:00 */
 		dst_local.year = 2000;
 		dst_local.month = 5; /* May */
 		dst_local.day = 1;

--- a/test/test_conversion_sql2c_timestamp.cc
+++ b/test/test_conversion_sql2c_timestamp.cc
@@ -290,13 +290,12 @@ class ConvertSQL2C_Timestamp_TZ : public ConvertSQL2C_Timestamp
 	void SetUp() override
 	{
 		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
-		ASSERT_EQ(putenv("TZ=NPT-5:45NTP"), 0);
+		ASSERT_EQ(putenv("TZ=NPT-5:45"), 0);
 		tzset();
 
 		/* The 'time_zone' & co. params are computed once, at library load ->
 		 * need to recompute after setting the TZ. */
 		ASSERT_TRUE(queries_init());
-		ASSERT_TRUE(convert_init());
 	}
 
 	void TearDown() override

--- a/test/test_conversion_sql2c_timestamp.cc
+++ b/test/test_conversion_sql2c_timestamp.cc
@@ -8,6 +8,7 @@
 #include "connected_dbc.h"
 
 #include <string.h>
+#include "convert.h" /* TM_TO_TIMESTAMP_STRUCT() */
 
 /* placeholders; will be undef'd and redef'd */
 #define SQL_VAL
@@ -19,7 +20,7 @@ class ConvertSQL2C_Timestamp : public ::testing::Test, public ConnectedDBC
 {
 
 	protected:
-		TIMESTAMP_STRUCT ts;
+		TIMESTAMP_STRUCT ts = {0};
 
 	void prepareAndBind(const char *jsonAnswer)
 	{
@@ -292,15 +293,12 @@ class ConvertSQL2C_Timestamp_TZ : public ConvertSQL2C_Timestamp
 		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
 		ASSERT_EQ(putenv("TZ=NPT-5:45"), 0);
 		tzset();
-
-		/* The 'time_zone' & co. params are computed once, at library load ->
-		 * need to recompute after setting the TZ. */
-		ASSERT_TRUE(queries_init());
 	}
 
 	void TearDown() override
 	{
 		ASSERT_EQ(putenv("TZ="), 0);
+		tzset();
 	}
 };
 
@@ -408,6 +406,133 @@ TEST_F(ConvertSQL2C_Timestamp_TZ, Datetime_offset_Str2Timestamp)
 #undef SQL_VAL_TS
 }
 
+
+class ConvertSQL2C_Timestamp_DST : public ConvertSQL2C_Timestamp
+{
+	protected:
+	struct tm no_dst_utc = {0};
+	struct tm dst_utc = {0};
+
+	void SetUp() override
+	{
+		ASSERT_EQ(putenv("TZ="), 0);
+		tzset();
+
+		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
+	}
+
+	void timestamp_utc_to_local(struct tm *utc, BOOL to_string);
+	void print_tm_timestamp(char *dest, size_t size,
+		const char *templ, struct tm *src);
+
+	BOOL dst_in_effect(struct tm *tm)
+	{
+		int month = tm->tm_mon + 1;
+		/* quick switch, only valid for the dates below */
+		return 3 < month && month <= 10;
+	}
+
+	public:
+	ConvertSQL2C_Timestamp_DST()
+	{
+		/* Construct the tm structs of dates when DST is not and is in effect,
+		 * respectively. The DST applicability will depend on the testing
+		 * machine's settings and tests will fail early if not suitable for
+		 * local machine. */
+
+		/* 2000-01-01T12:00:00Z */
+		no_dst_utc.tm_year = 2000 - 1900;
+		no_dst_utc.tm_mon = 0; /* Jan */
+		no_dst_utc.tm_mday = 1;
+		no_dst_utc.tm_hour = 12;
+
+		/* 2000-05-01T12:00:00Z */
+		dst_utc.tm_year = 2000 - 1900;
+		dst_utc.tm_mon = 4; /* May */
+		dst_utc.tm_mday = 1;
+		dst_utc.tm_hour = 12;
+	}
+};
+
+void ConvertSQL2C_Timestamp_DST::print_tm_timestamp(char *dest, size_t size,
+		const char *templ, struct tm *src)
+{
+	int n = snprintf(dest, size, templ,
+			src->tm_year + 1900, src->tm_mon + 1, src->tm_mday,
+			src->tm_hour, src->tm_min, src->tm_sec);
+	ASSERT_TRUE(0 < n && n < size);
+
+}
+
+void ConvertSQL2C_Timestamp_DST::timestamp_utc_to_local(struct tm *utc,
+		BOOL to_string)
+{
+	const char answer_template[] =
+		"{\"columns\": [{\"name\": \"value\", \"type\": \"DATETIME\"}],"
+		"\"rows\": [[\"%04d-%02d-%02dT%02d:%02d:%02dZ\"]]}";
+	const char expected_template[] = "%04d-%02d-%02d %02d:%02d:%02d";
+
+	utc->tm_isdst = -1; /* shouldn't matter, but set it: unknown DST */
+	time_t utc_ts = timegm(utc);
+	ASSERT_TRUE(utc_ts != (time_t)-1);
+	struct tm *local_tm_ptr = localtime(&utc_ts);
+	ASSERT_TRUE(local_tm_ptr != NULL);
+
+	TIMESTAMP_STRUCT local_ts = {0};
+	/* If this fails, the test is not suitable: the DTS applicability is not
+	 * known or in-line with used dates. */
+	EXPECT_TRUE((0 <= local_tm_ptr->tm_isdst) &&
+			(0 < local_tm_ptr->tm_isdst) == dst_in_effect(utc));
+	TM_TO_TIMESTAMP_STRUCT(local_tm_ptr, &local_ts, 0LU);
+
+	char fetched[1024], expected[1024];
+	char answer[1024];
+	ASSERT_LT(sizeof(answer_template) + ISO8601_TS_UTC_LEN(0), sizeof(answer));
+	print_tm_timestamp(answer, sizeof(answer), answer_template, utc);
+
+	if (to_string) {
+		prepareStatement(answer);
+
+		ret = SQLBindCol(stmt, /*col#*/1, SQL_C_CHAR, fetched, sizeof(fetched),
+				&ind_len);
+		ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+		print_tm_timestamp(expected, sizeof(expected), expected_template,
+				local_tm_ptr);
+	} else {
+		prepareAndBind(answer);
+	}
+
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	if (to_string) {
+		ASSERT_STREQ(fetched, expected);
+	} else {
+		ASSERT_TRUE(memcmp(&local_ts, /*fetched result*/&ts, sizeof(ts)) == 0);
+	}
+
+}
+
+TEST_F(ConvertSQL2C_Timestamp_DST, Timestamp_no_DST_UTC2Local_TS)
+{
+	timestamp_utc_to_local(&no_dst_utc, FALSE);
+}
+
+TEST_F(ConvertSQL2C_Timestamp_DST, Timestamp_DST_UTC2Local_TS)
+{
+	timestamp_utc_to_local(&dst_utc, FALSE);
+}
+
+TEST_F(ConvertSQL2C_Timestamp_DST, Timestamp_no_DST_UTC2Local_Char)
+{
+	timestamp_utc_to_local(&no_dst_utc, TRUE);
+}
+
+TEST_F(ConvertSQL2C_Timestamp_DST, Timestamp_DST_UTC2Local_Char)
+{
+	timestamp_utc_to_local(&dst_utc, TRUE);
+}
 
 
 } // test namespace

--- a/test/test_conversion_sql2c_timestamp.cc
+++ b/test/test_conversion_sql2c_timestamp.cc
@@ -292,6 +292,11 @@ class ConvertSQL2C_Timestamp_TZ : public ConvertSQL2C_Timestamp
 		((esodbc_dbc_st *)dbc)->apply_tz = TRUE;
 		ASSERT_EQ(putenv("TZ=NPT-5:45NTP"), 0);
 		tzset();
+
+		/* The 'time_zone' & co. params are computed once, at library load ->
+		 * need to recompute after setting the TZ. */
+		ASSERT_TRUE(queries_init());
+		ASSERT_TRUE(convert_init());
 	}
 
 	void TearDown() override


### PR DESCRIPTION
This PR fixes the application of the DST offset, both to time values, in case local times are used, and to the `time_zone` request parameter sent to ES. 

It also enables the calculation of this offset on a per-request basis, thus making the driver work correctly during the DST setting changing (i.e. it should not require an application restart after the local time advanced or was set back).