### PR TITLE
Introduce auto-escaping of pattern arguments in catalog functions

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1307,7 +1307,7 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 	dbc->mfield_lenient = wstr2bool(&attrs->mfield_lenient);
 	INFOH(dbc, "multifield lenient: %s.",
 		dbc->mfield_lenient ? "true" : "false");
-	/* auto escape patter value argument */
+	/* auto escape pattern value argument */
 	dbc->auto_esc_pva = wstr2bool(&attrs->auto_esc_pva);
 	INFOH(dbc, "auto escape PVA: %s.", dbc->auto_esc_pva ? "true" : "false");
 

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1307,6 +1307,9 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 	dbc->mfield_lenient = wstr2bool(&attrs->mfield_lenient);
 	INFOH(dbc, "multifield lenient: %s.",
 		dbc->mfield_lenient ? "true" : "false");
+	/* auto escape patter value argument */
+	dbc->auto_esc_pva = wstr2bool(&attrs->auto_esc_pva);
+	INFOH(dbc, "auto escape PVA: %s.", dbc->auto_esc_pva ? "true" : "false");
 
 	return SQL_SUCCESS;
 err:

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -49,6 +49,7 @@
 #define ESODBC_ALL_COLUMNS			"%"
 #define ESODBC_STRING_DELIM			"'"
 #define ESODBC_QUOTE_CHAR			"\""
+#define ESODBC_CHAR_ESCAPE			'\\'
 #define ESODBC_PATTERN_ESCAPE		"\\"
 #define ESODBC_CATALOG_SEPARATOR	":"
 #define ESODBC_CATALOG_TERM			"catalog"
@@ -176,6 +177,7 @@
 /* default version checking mode: strict, major, none (dbg only) */
 #define ESODBC_DEF_VERSION_CHECKING	ESODBC_DSN_VC_STRICT
 #define ESODBC_DEF_MFIELD_LENIENT	"true"
+#define ESODBC_DEF_ESC_PVA			"true"
 
 /*
  *

--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -78,6 +78,7 @@ int assign_dsn_attr(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
+		{&MK_WSTR(ESODBC_DSN_ESC_PVA), &attrs->auto_esc_pva},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -410,6 +411,7 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
+		{&MK_WSTR(ESODBC_DSN_ESC_PVA), &attrs->auto_esc_pva},
 		{&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &attrs->trace_enabled},
 		{&MK_WSTR(ESODBC_DSN_TRACE_FILE), &attrs->trace_file},
 		{&MK_WSTR(ESODBC_DSN_TRACE_LEVEL), &attrs->trace_level},
@@ -680,6 +682,11 @@ BOOL write_system_dsn(esodbc_dsn_attrs_st *new_attrs,
 			old_attrs ? &old_attrs->mfield_lenient : NULL
 		},
 		{
+			&MK_WSTR(ESODBC_DSN_ESC_PVA),
+			&new_attrs->auto_esc_pva,
+			old_attrs ? &old_attrs->auto_esc_pva : NULL
+		},
+		{
 			&MK_WSTR(ESODBC_DSN_TRACE_ENABLED), &new_attrs->trace_enabled,
 			old_attrs ? &old_attrs->trace_enabled : NULL
 		},
@@ -768,6 +775,7 @@ long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 		{&attrs->sci_floats, &MK_WSTR(ESODBC_DSN_SCI_FLOATS)},
 		{&attrs->version_checking, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING)},
 		{&attrs->mfield_lenient, &MK_WSTR(ESODBC_DSN_MFIELD_LENIENT)},
+		{&attrs->auto_esc_pva, &MK_WSTR(ESODBC_DSN_ESC_PVA)},
 		{&attrs->trace_enabled, &MK_WSTR(ESODBC_DSN_TRACE_ENABLED)},
 		{&attrs->trace_file, &MK_WSTR(ESODBC_DSN_TRACE_FILE)},
 		{&attrs->trace_level, &MK_WSTR(ESODBC_DSN_TRACE_LEVEL)},
@@ -861,6 +869,9 @@ void assign_dsn_defaults(esodbc_dsn_attrs_st *attrs)
 	res |= assign_dsn_attr(attrs,
 			&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT),
 			&MK_WSTR(ESODBC_DEF_MFIELD_LENIENT), /*overwrite?*/FALSE);
+	res |= assign_dsn_attr(attrs,
+			&MK_WSTR(ESODBC_DSN_ESC_PVA),
+			&MK_WSTR(ESODBC_DEF_ESC_PVA), /*overwrite?*/FALSE);
 
 	/* default: no trace file */
 	res |= assign_dsn_attr(attrs,

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -37,6 +37,7 @@
 #define ESODBC_DSN_SCI_FLOATS		"ScientificFloats"
 #define ESODBC_DSN_VERSION_CHECKING	"VersionChecking"
 #define ESODBC_DSN_MFIELD_LENIENT	"MultiFieldLenient"
+#define ESODBC_DSN_ESC_PVA			"AutoEscapePVA"
 #define ESODBC_DSN_TRACE_ENABLED	"TraceEnabled"
 #define ESODBC_DSN_TRACE_FILE		"TraceFile"
 #define ESODBC_DSN_TRACE_LEVEL		"TraceLevel"
@@ -77,10 +78,11 @@ typedef struct {
 	wstr_st sci_floats;
 	wstr_st version_checking;
 	wstr_st mfield_lenient;
+	wstr_st auto_esc_pva;
 	wstr_st trace_enabled;
 	wstr_st trace_file;
 	wstr_st trace_level;
-#define ESODBC_DSN_ATTRS_COUNT	25
+#define ESODBC_DSN_ATTRS_COUNT	26
 	SQLWCHAR buff[ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN];
 	/* DSN reading/writing functions are passed a SQLSMALLINT lenght param */
 #if SHRT_MAX < ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -163,6 +163,7 @@ typedef struct struct_dbc {
 		ESODBC_FLTS_AUTO,
 	} sci_floats; /* floats printing on conversion */
 	BOOL mfield_lenient; /* 'field_multi_value_leniency' request param */
+	BOOL auto_esc_pva; /* auto-escape PVA args in catalog functions */
 
 	esodbc_estype_st *es_types; /* array with ES types */
 	SQLULEN no_types; /* number of types in array */

--- a/driver/util.h
+++ b/driver/util.h
@@ -265,6 +265,14 @@ SQLRETURN write_wstr(SQLHANDLE hnd, SQLWCHAR *dest, wstr_st *src,
  */
 cstr_st TEST_API *wstr_to_utf8(wstr_st *src, cstr_st *dst);
 
+/* Escape `%`, `_`, `\` characters in 'src'.
+ * If not 'force'-d, the escaping will stop on detection of pre-existing
+ * escaping(*), OR if the chars to be escaped are stand-alone.
+ * (*): invalid/incomplete escaping sequences - `\\\` -  are still considered
+ * as containing escaping.
+ * Returns: TRUE, if escaping has been applied  */
+BOOL TEST_API metadata_id_escape(wstr_st *src, wstr_st *dst, BOOL force);
+
 /*
  * Printing aids.
  */

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -71,8 +71,6 @@ static const char systypes_answer[] = "\
 			false, null, null, null, 16, 0, null, null],\
 		[\"DATE\", 91, 10, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, null, null, 91, 0, null, null],\
-		[\"TIME\", 92, 18, \"'\", \"'\", null, 2, false, 3, true, false,\
-			false, null, null, null, 91, 0, null, null],\
 		[\"DATETIME\", 93, 24, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, 3, 3, 9, 3, null, null],\
 		[\"INTERVAL_YEAR\", 101, 7, \"'\", \"'\", null, 2, false, 3, true,\

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -71,6 +71,8 @@ static const char systypes_answer[] = "\
 			false, null, null, null, 16, 0, null, null],\
 		[\"DATE\", 91, 10, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, null, null, 91, 0, null, null],\
+		[\"TIME\", 92, 18, \"'\", \"'\", null, 2, false, 3, true, false,\
+			false, null, null, null, 91, 0, null, null],\
 		[\"DATETIME\", 93, 24, \"'\", \"'\", null, 2, false, 3, true, false,\
 			false, null, 3, 3, 9, 3, null, null],\
 		[\"INTERVAL_YEAR\", 101, 7, \"'\", \"'\", null, 2, false, 3, true,\

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -181,8 +181,17 @@ TEST_F(Util, metadata_id_escape)
 	ASSERT_FALSE(metadata_id_escape(&src, &dst, FALSE));
 	ASSERT_TRUE(EQ_WSTR(&dst, &exp));
 
-	src = WSTR_INIT("%"); // stand-alone `\`, but forced
+	src = WSTR_INIT("%"); // stand-alone `%`, but forced
 	exp = WSTR_INIT("\\%");
+	ASSERT_TRUE(metadata_id_escape(&src, &dst, TRUE));
+	ASSERT_TRUE(EQ_WSTR(&dst, &exp));
+
+	src = exp = WSTR_INIT("_"); // stand-alone `_`
+	ASSERT_FALSE(metadata_id_escape(&src, &dst, FALSE));
+	ASSERT_TRUE(EQ_WSTR(&dst, &exp));
+
+	src = WSTR_INIT("_"); // stand-alone `_`, but forced
+	exp = WSTR_INIT("\\_");
 	ASSERT_TRUE(metadata_id_escape(&src, &dst, TRUE));
 	ASSERT_TRUE(EQ_WSTR(&dst, &exp));
 


### PR DESCRIPTION
This PR adds a new connection string parameter to control the escaping of the patern value arguments in catalog functions.

The PVA arguments can use `_` and `%` as special characters to build patern matching values. However, some applications (likely due to some more drivers/DBs misbehaving) use these chars as regular ones, which can lead to ES returning more data than the app intended.

With the auto escaping (on by default), the driver will inspect the arguments and will escape these special characters if not already done by the application. (This is not standards compliant, that's why it's a config option.)

This is the equivalent of https://github.com/elastic/elasticsearch/pull/40661.

The PR also adds more integration tests for the catalog functions.