### PR TITLE
DST fixes unit test

### DIFF
--- a/test/integration/testing.py
+++ b/test/integration/testing.py
@@ -14,7 +14,7 @@ from data import TestData, BATTERS_TEMPLATE
 
 UID = "elastic"
 CONNECT_STRING = 'Driver={Elasticsearch Driver};UID=%s;PWD=%s;Secure=0;' % (UID, Elasticsearch.AUTH_PASSWORD)
-CATALOG = "distribution_run"
+CATALOG = "elasticsearch"
 
 class Testing(unittest.TestCase):
 

--- a/test/test_conversion_c2sql_timestamp.cc
+++ b/test/test_conversion_c2sql_timestamp.cc
@@ -427,12 +427,6 @@ class ConvertC2SQL_Timestamp_DST : public ConvertC2SQL_Timestamp
 
 	void timestamp_local_to_utc(TIMESTAMP_STRUCT *, BOOL);
 
-	BOOL dst_in_effect(TIMESTAMP_STRUCT *ts)
-	{
-		/* quick switch, only valid for the dates below */
-		return 3 < ts->month && ts->month <= 10;
-	}
-
 	public:
 	ConvertC2SQL_Timestamp_DST()
 	{
@@ -505,10 +499,6 @@ void ConvertC2SQL_Timestamp_DST::timestamp_local_to_utc(
 	ASSERT_TRUE(local_tm_ptr != NULL);
 	TIMESTAMP_STRUCT dst_local = {0};
 	TM_TO_TIMESTAMP_STRUCT(local_tm_ptr, &dst_local, src_local->fraction);
-
-	/* check if test is valid for the local machine */
-	EXPECT_TRUE((0 <= local_tm_ptr->tm_isdst) &&
-		(0 < local_tm_ptr->tm_isdst) == dst_in_effect(src_local));
 
 	/* compare source local timestamp to that UTC'd by the driver and
 	 * localtime'd back above by the test */

--- a/test/test_conversion_sql2c_timestamp.cc
+++ b/test/test_conversion_sql2c_timestamp.cc
@@ -562,20 +562,12 @@ class ConvertSQL2C_Timestamp_DST : public ConvertSQL2C_Timestamp
 	void print_tm_timestamp(char *dest, size_t size,
 		const char *templ, struct tm *src);
 
-	BOOL dst_in_effect(struct tm *tm)
-	{
-		int month = tm->tm_mon + 1;
-		/* quick switch, only valid for the dates below */
-		return 3 < month && month <= 10;
-	}
-
 	public:
 	ConvertSQL2C_Timestamp_DST()
 	{
 		/* Construct the tm structs of dates when DST is not and is in effect,
 		 * respectively. The DST applicability will depend on the testing
-		 * machine's settings and tests will fail early if not suitable for
-		 * local machine. */
+		 * machine's settings. */
 
 		/* 2000-01-01T12:00:00Z */
 		no_dst_utc.tm_year = 2000 - 1900;
@@ -616,10 +608,6 @@ void ConvertSQL2C_Timestamp_DST::timestamp_utc_to_local(struct tm *utc,
 	ASSERT_TRUE(local_tm_ptr != NULL);
 
 	TIMESTAMP_STRUCT local_ts = {0};
-	/* If this fails, the test is not suitable: the DTS applicability is not
-	 * known or in-line with used dates. */
-	EXPECT_TRUE((0 <= local_tm_ptr->tm_isdst) &&
-			(0 < local_tm_ptr->tm_isdst) == dst_in_effect(utc));
 	TM_TO_TIMESTAMP_STRUCT(local_tm_ptr, &local_ts, 0LU);
 
 	char fetched[1024], expected[1024];


### PR DESCRIPTION
This PR removes a test from DST suites that was just checking that the chosen test dates have a certain DST applicability. This check fails on machines running on UTC machines.

It also updates the cluster name used in integration tests to what Elasticsearch now advertises in the snapshots: `elasticsearch`.