### PR TITLE
Fix integration testing app to run on non-Win platforms. Update ES setup sequence

### DIFF
--- a/test/integration/testing.py
+++ b/test/integration/testing.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-import pyodbc
 import datetime
 import hashlib
 import unittest
@@ -30,6 +29,9 @@ class Testing(unittest.TestCase):
 		self._data = test_data
 		self._dsn = dsn if dsn else CONNECT_STRING
 		print("Using DSN: '%s'." % self._dsn)
+
+		# only import pyODBC if running tests (vs. for instance only loading test data in ES)
+		import pyodbc
 
 	def _reconstitute_csv(self, index_name):
 		with pyodbc.connect(self._dsn) as cnxn:


### PR DESCRIPTION
This PR adds a few small changes to the integration testing application to:
- allow it to run on non-Windows platforms: the process handling flags and networking exceptions differ in this case;
- relax environment requirements, removing the pyODBC dependency, if not performing tests;
- fix setting up Elasticsearch for testing, swapping the trial-mode activation with password generation blocks, since the former is now password-protected.