### PR TITLE
Introduce geo support

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -51,6 +51,9 @@
 #define TYPE_KEYWORD		"KEYWORD"
 /* 8 */
 #define TYPE_DATETIME		"DATETIME"
+/* 9 */
+#define TYPE_GEOSHAPE		"GEO_SHAPE"
+#define TYPE_GEOPOINT		"GEO_POINT"
 /* 10 */
 #define TYPE_HALF_FLOAT		"HALF_FLOAT"
 /* 11 */
@@ -1892,6 +1895,28 @@ static BOOL elastic_name2types(wstr_st *type_name,
 			}
 			break;
 
+		/* 9: GEO_POINT, GEO_SHAPE */
+		case sizeof(TYPE_GEOSHAPE) - 1:
+			switch (tolower(type_name->str[/*'GEO_x'*/4])) {
+				case (SQLWCHAR)'s':
+					if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_GEOSHAPE),
+							type_name->cnt)) {
+						*c_sql = ES_GEO_TO_CSQL;
+						*sql = ES_GEO_TO_SQL;
+						return TRUE;
+					}
+					break;
+				case (SQLWCHAR)'p':
+					if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_GEOPOINT),
+							type_name->cnt)) {
+						*c_sql = ES_GEO_TO_CSQL;
+						*sql = ES_GEO_TO_SQL;
+						return TRUE;
+					}
+					break;
+			}
+			break;
+
 		/* 10: HALF_FLOAT */
 		case sizeof(TYPE_HALF_FLOAT) - 1:
 			if (! wmemncasecmp(type_name->str, MK_WPTR(TYPE_HALF_FLOAT),
@@ -2180,7 +2205,8 @@ static void *copy_types_rows(esodbc_dbc_st *dbc, estype_row_st *type_row,
 		 * apply any needed fixes
 		 */
 
-		/* notify if scales extremes are different */
+		/* notify if scales extremes are different, since ES/SQL makes use of
+		 * fixed types only. */
 		if (types[i].maximum_scale != types[i].minimum_scale) {
 			INFOH(dbc, "type `" LWPDL "` returned with non-equal max/min "
 				"scale: %d/%d -- using the max.", LWSTR(&types[i].type_name),
@@ -2204,6 +2230,10 @@ static void *copy_types_rows(esodbc_dbc_st *dbc, estype_row_st *type_row,
 		 * => change it to SQL_BIT */
 		if (types[i].data_type == ESODBC_SQL_BOOLEAN) {
 			types[i].data_type = ES_BOOLEAN_TO_SQL;
+		}
+		/* GEO (SHAPE, POINT) types are WKT encodings */
+		if (types[i].data_type == ESODBC_SQL_GEO) {
+			types[i].data_type = ES_GEO_TO_SQL;
 		}
 
 		/* .data_type is used in data conversions -> make sure the SQL type
@@ -2933,6 +2963,9 @@ SQLRETURN EsSQLSetConnectAttrW(
 			RET_HDIAGS(dbc, SQL_STATE_HYC00);
 
 #ifndef NDEBUG
+		/* MicroStrategy Desktop invoked */
+		case 1041:
+		case 1042:
 		/* MS Access/Jet proprietary info type */
 		case 30002:
 			ERRH(dbc, "unsupported info type.");

--- a/driver/connect.h
+++ b/driver/connect.h
@@ -68,6 +68,10 @@
 /*
  * ES-non mappable
  */
+/* 114: ??? -> SQL_C_WCHAR */
+#define ES_GEO_TO_CSQL			SQL_C_WCHAR /* XXX: CBOR needs _CHAR */
+#define ES_GEO_TO_SQL			SQL_VARCHAR
+
 /* 1111: ??? -> SQL_C_BINARY */
 #define ES_UNSUPPORTED_TO_CSQL	SQL_C_BINARY
 #define ES_UNSUPPORTED_TO_SQL	ESODBC_SQL_UNSUPPORTED

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -388,6 +388,7 @@
  * ES specific data types
  */
 #define ESODBC_SQL_BOOLEAN			16
+#define ESODBC_SQL_GEO				114
 #define ESODBC_SQL_NULL				0
 #define ESODBC_SQL_UNSUPPORTED		1111
 #define ESODBC_SQL_OBJECT			2002

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1525,7 +1525,8 @@ static esodbc_estype_st *match_es_type(esodbc_rec_st *arec,
 		}
 	}
 
-	/* app specified an SQL type with no direct mapping to an ES/SQL type */
+	/* app specified an SQL type with no direct mapping to an ES/SQL type
+	 * TODO: IP, GEO? */
 	switch (irec->meta_type) {
 		case METATYPE_EXACT_NUMERIC:
 			assert(irec->concise_type == SQL_DECIMAL ||


### PR DESCRIPTION
This PR adds initial support for the Geo types: shape and point.
The driver will now recognize the new data types and will allow piping through the data as fetched from Elasticsearch, WKT encoded.

Any 3rd party application that will want to work with the type can use their own library on top of ODBC. For existing apps, the driver will return the data as text.