### PR TITLE
Fixes: correct check on truncation failure. Reinit IRD on statement closing. Logging format descriptors

### DIFF
--- a/driver/catalogue.c
+++ b/driver/catalogue.c
@@ -417,12 +417,7 @@ SQLRETURN EsSQLTablesW(
 
 	DBGH(stmt, "tables catalog SQL [%zu]:`" LWPDL "`.", pos, (int)pos, pbuf);
 
-	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
-	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, pbuf, pos);
-	if (SQL_SUCCEEDED(ret)) {
-		ret = EsSQLExecute(stmt);
-	}
+	ret = EsSQLExecDirectW(stmt, pbuf, (SQLINTEGER)pos);
 end:
 	free(pbuf);
 	return ret;
@@ -573,12 +568,7 @@ SQLRETURN EsSQLColumnsW
 		goto end;
 	}
 
-	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
-	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, pbuf, cnt);
-	if (SQL_SUCCEEDED(ret)) {
-		ret = EsSQLExecute(stmt);
-	}
+	ret = EsSQLExecDirectW(stmt, pbuf, (SQLINTEGER)cnt);
 end:
 	free(pbuf);
 	return ret;

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -3300,7 +3300,8 @@ static SQLRETURN wstr_to_string(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		wstr_to_wstr(arec, irec, data_ptr, octet_len_ptr, wstr, chars_0);
 
 	/* if truncation occured, only succeed if fractional seconds are cut out */
-	if (min_xfer && HDRH(stmt)->diag.state == SQL_STATE_01004) {
+	if (ret == SQL_SUCCESS_WITH_INFO && min_xfer &&
+		HDRH(stmt)->diag.state == SQL_STATE_01004) {
 		assert(SQL_SUCCEEDED(ret));
 
 		usize = (arec_type == SQL_C_CHAR) ? sizeof(SQLCHAR) : sizeof(SQLWCHAR);

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -451,7 +451,7 @@ SQLRETURN EsSQLFreeStmt(SQLHSTMT StatementHandle, SQLUSMALLINT Option)
 		 * pending results." */
 		case SQL_CLOSE:
 			DBGH(stmt, "closing.");
-			clear_desc(stmt->ird, FALSE /*keep the header values*/);
+			clear_desc(stmt->ird, TRUE);
 			break;
 
 		/* "Sets the SQL_DESC_COUNT field of the APD to 0, releasing all

--- a/driver/info.c
+++ b/driver/info.c
@@ -1209,10 +1209,9 @@ SQLRETURN EsSQLGetTypeInfoW(SQLHSTMT StatementHandle, SQLSMALLINT DataType)
 {
 #define SQL_TYPES_STMT		"SYS TYPES"
 
-	SQLRETURN ret;
 	esodbc_stmt_st *stmt = STMH(StatementHandle);
 	SQLWCHAR wbuff[sizeof(SQL_TYPES_STMT " 32767")];
-	size_t cnt;
+	int cnt;
 
 	DBGH(stmt, "requested type description for type %hd.", DataType);
 	cnt = swprintf(wbuff, sizeof(wbuff)/sizeof(*wbuff),
@@ -1222,13 +1221,7 @@ SQLRETURN EsSQLGetTypeInfoW(SQLHSTMT StatementHandle, SQLSMALLINT DataType)
 		RET_HDIAGS(stmt, SQL_STATE_HY000);
 	}
 
-	ret = EsSQLFreeStmt(stmt, ESODBC_SQL_CLOSE);
-	assert(SQL_SUCCEEDED(ret)); /* can't return error */
-	ret = attach_sql(stmt, wbuff, cnt);
-	if (SQL_SUCCEEDED(ret)) {
-		ret = EsSQLExecute(stmt);
-	}
-	return ret;
+	return EsSQLExecDirectW(stmt, wbuff, cnt);
 
 #	undef SQL_TYPES_STMT
 }


### PR DESCRIPTION
This PR bundles a few minor fixes:

1. A check on conversion failure was incorrectly taking into account the result of a previous column conversion on the same row. The defect was without practical implications, since a second, impossible condition would have had to match to lead to an incorrect failure. However the incorrect first check lead to a failing assertion.

2. The IRD descriptor was not re-init'd on statement handle closing. This defect is fixed just for good house-keeping, since the descriptor would be re-init'd on attaching a new result set to it (which happens regularly when the result for a query is being paged / using a cursor). Along with this, some code duplication has been removed.

3. A few logging statements had the wrong format specifiers, mostly expecting signed, instead of the correct unsigned types of the integer variants.