### PR TITLE
Enh: trace in-driver execution time. Extended logging buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,11 @@ if (${WIN32})
 	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /DTEST_API=")
 	set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE} /DTEST_API=")
 
-	# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DNDEBUG")
+	# Only used when a long logging message is required for troubleshooting
+	# (like one entire server answer).
+	#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DWITH_EXTENDED_BUFF_LOG")
+	# Account for the time the process spends within the driver.
+	#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DWITH_OAPI_TIMING")
 else (${WIN32})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
 endif (${WIN32})

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -26,7 +26,7 @@
 
 #ifdef WITH_OAPI_TIMING
 volatile LONG64 api_ticks = 0;
-clock_t thread_local in_ticks;
+clock_t thread_local in_ticks = 0;
 #endif /* WITH_API_TIMING */
 
 static BOOL driver_init()

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -24,18 +24,14 @@
 		RET_HDIAGS(hnd, SQL_STATE_HYC00); \
 	} while (0)
 
+#ifdef WITH_OAPI_TIMING
+volatile LONG64 api_ticks = 0;
+clock_t thread_local in_ticks;
+#endif /* WITH_API_TIMING */
 
 static BOOL driver_init()
 {
 	if (! log_init()) {
-		return FALSE;
-	}
-	INFO("initializing driver.");
-	if (! queries_init()) {
-		return FALSE;
-	}
-	convert_init();
-	if (! connect_init()) {
 		return FALSE;
 	}
 #ifndef NDEBUG
@@ -49,6 +45,14 @@ static BOOL driver_init()
 		_CrtSetReportFile(_CRT_ASSERT, _gf_log->handle);
 	}
 #endif /* !NDEBUG */
+	INFO("initializing driver.");
+	if (! queries_init()) {
+		return FALSE;
+	}
+	convert_init();
+	if (! connect_init()) {
+		return FALSE;
+	}
 	return TRUE;
 }
 
@@ -96,6 +100,10 @@ BOOL WINAPI DllMain(
 				ERR("leaks dumped: %d.", _CrtDumpMemoryLeaks());
 			}
 #endif /* !NDEBUG */
+#ifdef WITH_OAPI_TIMING
+			INFO("total in-driver time (secs): %.3f.",
+				(float)api_ticks / CLOCKS_PER_SEC);
+#endif /* WITH_OAPI_TIMING */
 			INFO("process %u detaching.", GetCurrentProcessId());
 			log_cleanup();
 			break;

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -155,6 +155,7 @@ class Elasticsearch(object):
 		if self.is_listening():
 			raise Exception("an Elasticsearch instance is already running")
 
+		print("Starting Elasticsearch with: %s" % start_script)
 		# don't daemonize to get the start logs inlined with those that this app generates
 		es_proc = psutil.Popen(start_script, close_fds=True, creationflags=creationflags)
 		atexit.register(Elasticsearch._stop_es, es_proc)


### PR DESCRIPTION
This PR adds the possibility to account for the time the execution
spends within the driver. For that, it simply adds up the ticks
accounted between entering and exiting any ODBC API call.

With it, now one can estimate roughly how much time the driver code
runs, as well as how long the driver waits for the REST calls (previously
available).

This time accounting is done globally and possibly across multiple
threads. Its mostly useful with single-threaded use, though.

The PR also adds the possibility to use a much larger logging
"extended" buffer. This is useful in troubleshooting cases where larger
logging meesages are required (such as when an entire server REST reply
is JSON object is needed).

Both of these features are disabled by default (for all build types).