### PR TITLE
CBOR support for result sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,10 +288,8 @@ add_custom_target(curlclean
 #
 set(TINYCBOR_PATH_SRC ${CMAKE_SOURCE_DIR}/libs/tinycbor CACHE PATH
 	"Lib tinycbor source path")
-aux_source_directory(${TINYCBOR_PATH_SRC}/src DRV_SRC)
-list(FILTER DRV_SRC EXCLUDE REGEX .*open_memstream.c$) # Win-unsupported
-list(FILTER DRV_SRC EXCLUDE REGEX .*cborparser.c$) # to be patched
-file(COPY ${TINYCBOR_PATH_SRC}/src/cborparser.c DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${TINYCBOR_PATH_SRC}/src/cborparser.c DESTINATION
+	${CMAKE_BINARY_DIR})
 # tinycbor doesn't expose (yet? #125) the text/binary string pointer, since the
 # string can span multiple stream chunks. However, in our case the CBOR object
 # is available entirely, so access to it can safely be had; this saves a
@@ -304,9 +302,13 @@ CborError cbor_value_get_string_chunk(CborValue *it,
 	CborError err = get_string_chunk(it, bufferptr, len);
 	return err != CborNoError ? err : preparse_next_value(it);
 }")
-aux_source_directory(${CMAKE_BINARY_DIR} DRV_SRC)
+list(APPEND DRV_SRC ${CMAKE_BINARY_DIR}/cborparser.c)
+list(APPEND DRV_SRC ${TINYCBOR_PATH_SRC}/src/cborvalidation.c)
+list(APPEND DRV_SRC ${TINYCBOR_PATH_SRC}/src/cborerrorstrings.c)
+list(APPEND DRV_SRC ${TINYCBOR_PATH_SRC}/src/cborencoder.c)
+list(APPEND DRV_SRC
+	${TINYCBOR_PATH_SRC}/src/cborencoder_close_container_checked.c)
 set(TINYCBOR_INC ${TINYCBOR_PATH_SRC}/src)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DWITHOUT_OPEN_MEMSTREAM")
 # limit how deep the parser will recurse (current need: 3)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DCBOR_PARSER_MAX_RECURSIONS=16")
 

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -235,6 +235,20 @@ static int debug_callback(CURL *handle, curl_infotype type, char *data,
 /*
  * "ptr points to the delivered data, and the size of that data is size
  * multiplied with nmemb."
+ *
+ * Note: Elasticsearch supports (atm.) no streaming API and ES/SQL doesn't
+ * either. This function will keep realloc'ing (if needed) until the entire
+ * page sent by ES/SQL is received. The alternative is to stream-parse.
+ * However, with text & binary data, the stream parsing libraries will ask the
+ * client to provide a buffer to copy the data into, out of potentially
+ * multiple received data chunks in the stream. Which could require an extra
+ * allocation and will always involve an extra copy (or more, for UTF-8
+ * decoding). With current design (= reply object in contiguous chunk) at
+ * least the copy is skipped, since the text/binary data is contiguous and
+ * ready to be read from the receive buffer directly.
+ *
+ * TODO: initial chunk size and incremental sizes for the reallocation should
+ * be better "calibrated" (/ follow some max/hysteretic curve).
  */
 static size_t write_callback(char *ptr, size_t size, size_t nmemb,
 	void *userdata)
@@ -740,10 +754,10 @@ SQLRETURN curl_post(esodbc_stmt_st *stmt, int url_type,
 	BOOL is_json;
 
 	if (dbc->pack_json) {
-		DBGH(stmt, "POSTing JSON type %d: [%zu] `" LCPDL "`.", url_type,
+		DBGH(stmt, "POSTing JSON to URL type %d: [%zu] `" LCPDL "`.", url_type,
 			req_body->cnt, LCSTR(req_body));
 	} else {
-		DBGH(stmt, "POSTing CBOR type %d: [%zu] `%s`.", url_type,
+		DBGH(stmt, "POSTing CBOR to URL type %d: [%zu] `%s`.", url_type,
 			req_body->cnt, cstr_hex_dump(req_body));
 	}
 
@@ -1515,7 +1529,7 @@ static BOOL parse_es_version_cbor(esodbc_dbc_st *dbc, cstr_st *rsp_body,
 	/* the _init() doesn't actually validate the object */
 	res = cbor_value_validate(&top_obj, ES_CBOR_PARSE_FLAGS);
 	CHK_RES(stmt, "failed to validate CBOR object: [%zu] `%s`",
-		stmt->rset.body.cnt, cstr_hex_dump(&stmt->rset.body));
+		rsp_body->cnt, cstr_hex_dump(rsp_body));
 #	endif /*0*/
 #	endif /* !NDEBUG */
 

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -3494,12 +3494,12 @@ static inline BOOL conv_implemented(SQLSMALLINT sqltype, SQLSMALLINT ctype)
 }
 
 
-/* Check if data types in returned columns are compabile with buffer types
- * bound for those columns OR if parameter data conversion is allowed.
+/* Check (1) if data types in returned columns are compabile with buffer types
+ * bound for those columns OR (2) if parameter data conversion is allowed.
  * idx:
  *     if > 0: parameter number for parameter binding;
- *     if < 0: indicator for bound columns check.
- *     */
+ *     if < 0: negated column number to check OR indicator to check all bound
+ *             columns (CONV_CHECK_ALL_COLS). */
 SQLRETURN convertability_check(esodbc_stmt_st *stmt, SQLINTEGER idx,
 	int *conv_code)
 {
@@ -3519,7 +3519,9 @@ SQLRETURN convertability_check(esodbc_stmt_st *stmt, SQLINTEGER idx,
 		axd = stmt->ard;
 		ixd = stmt->ird;
 
-		start = 0;
+		/* if this is a SQLGetData() call, only check the one bound column */
+		assert(idx == CONV_CHECK_ALL_COLS || STMT_GD_CALLING(stmt));
+		start = (idx == CONV_CHECK_ALL_COLS) ? 0 : -idx - 1;
 		stop = axd->count < ixd->count ? axd->count : ixd->count;
 	} else {
 		/*

--- a/driver/convert.h
+++ b/driver/convert.h
@@ -21,6 +21,15 @@ SQLULEN get_param_size(esodbc_rec_st *irec);
 inline void *deferred_address(SQLSMALLINT field_id, size_t pos,
 	esodbc_rec_st *rec);
 
+
+/* column and parameters are all SQLUSMALLINT (unsigned short) */
+#define CONV_CHECK_ALL_COLS		(- ((SQLINTEGER)USHRT_MAX + 1))
+/* Check (1) if data types in returned columns are compabile with buffer types
+ * bound for those columns OR (2) if parameter data conversion is allowed.
+ * idx:
+ *     if > 0: parameter number for parameter binding;
+ *     if < 0: negated column number to check OR indicator to check all bound
+ *             columns (CONV_CHECK_ALL_COLS). */
 SQLRETURN convertability_check(esodbc_stmt_st *stmt, SQLINTEGER idx,
 	int *conv_code);
 BOOL update_crr_date(struct tm *now);

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1253,7 +1253,7 @@ static SQLRETURN set_row_diag(esodbc_desc_st *ird,
 	SQLULEN pos, SQLINTEGER colno)
 {
 	esodbc_stmt_st *stmt = HDRH(ird)->stmt;
-	SQLWCHAR wbuff[SQL_MAX_MESSAGE_LENGTH], *wmsg;
+	SQLWCHAR wbuff[SQL_MAX_MESSAGE_LENGTH], *wmsg = NULL;
 	int res;
 
 	if (ird->array_status_ptr) {
@@ -1261,9 +1261,9 @@ static SQLRETURN set_row_diag(esodbc_desc_st *ird,
 	}
 	if (msg) {
 		res = ascii_c2w((SQLCHAR *)msg, wbuff, SQL_MAX_MESSAGE_LENGTH - 1);
-		wmsg = 0 < res ? wbuff : NULL;
-	} else {
-		wmsg = NULL;
+		if (0 < res) {
+			wmsg = wbuff;
+		}
 	}
 	return post_row_diagnostic(stmt, state, wmsg, /*code*/0,
 			stmt->tv_rows + /*current*/1, colno);

--- a/driver/tinycbor.h
+++ b/driver/tinycbor.h
@@ -75,8 +75,14 @@ static inline size_t cbor_str_obj_len(size_t item_len)
  * given key, if that exists */
 CborError cbor_map_advance_to_key(CborValue *it, const char *key,
 	size_t key_len, CborValue *val);
+/* similar to cbor_value_leave_container(), but the iterator may find itself
+ * anywhere within the container (and not necessarily at the end of it). */
+CborError cbor_value_exit_container(CborValue *cont, CborValue *it);
+/* Looks up a number of 'cnt' objects mapped to the 'keys' of given
+ * 'len[gth]s'. If a key is not found, the corresponding objects are marked
+ * with an invalid type. */
 CborError cbor_map_lookup_keys(CborValue *map, size_t cnt,
-	const char **keys, const size_t *lens, CborValue **objs, BOOL drain);
+	const char **keys, const size_t *lens, CborValue **objs);
 CborError cbor_container_count(CborValue cont, size_t *count);
 CborError cbor_get_array_count(CborValue arr, size_t *count);
 CborError cbor_container_is_empty(CborValue cont, BOOL *empty);

--- a/driver/util.c
+++ b/driver/util.c
@@ -529,12 +529,12 @@ SQLRETURN write_wstr(SQLHANDLE hnd, SQLWCHAR *dest, wstr_st *src,
 {
 	size_t wide_avail;
 
+	DBGH(hnd, "copying %zd wchars (`" LWPDL "`) into buffer @0x%p, of %dB "
+		"len; out-len @0x%p.", src->cnt, LWSTR(src), dest, avail, usedp);
+
 	/* cnt must not count the 0-term (XXX: ever need to copy 0s?) */
 	assert(src->cnt <= 0 || src->str[src->cnt - 1]);
 	assert(src->cnt <= 0 || src->str[src->cnt] == 0);
-
-	DBGH(hnd, "copying %zd wchars (`" LWPDL "`) into buffer @0x%p, of %dB "
-		"len; out-len @0x%p.", src->cnt, LWSTR(src), dest, avail, usedp);
 
 	if (usedp) {
 		/* how many bytes are available to return (not how many would be


### PR DESCRIPTION
This PR extends the CBOR support with the ability to read the
CBOR-encapsulated result sets.

The PR also makes fetching data more efficient with the SQLGetData()
(the alternative to the generally more efficient SQLBindCol()). The
implementation still uses punctual column binding and unbinding, but
SQLFetch() will now cache the source JSON/CBOR object into IRD's records
and will no longer walk the entire list of instantied ARD records all
the way to the ad-hoc bound column.

Counting the total number of rows returned for a query has been changed
to cope with ES's use of indefinite-size arrays, to avoid iterating
twice over the rows in a page.