### PR TITLE
fix length read from app ptr when param binding

### DIFF
--- a/test/test_conversion_c2sql_null.cc
+++ b/test/test_conversion_c2sql_null.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <gtest/gtest.h>
+#include "connected_dbc.h"
+
+namespace test {
+
+class ConvertC2SQL_Null : public ::testing::Test, public ConnectedDBC {
+};
+
+
+TEST_F(ConvertC2SQL_Null, CStr2Boolean_null)
+{
+	prepareStatement();
+
+	SQLCHAR val[] = "1";
+	SQLLEN osize = SQL_NULL_DATA;
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+			ESODBC_SQL_BOOLEAN, /*size*/0, /*decdigits*/0, val,
+			sizeof(val) - /*\0*/1, &osize);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"BOOLEAN\", \"value\": null}]");
+}
+
+TEST_F(ConvertC2SQL_Null, WStr2Null)
+{
+	prepareStatement();
+
+	SQLWCHAR val[] = L"0X";
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+			ESODBC_SQL_NULL, /*size*/0, /*decdigits*/0, val, 0, NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"NULL\", \"value\": null}]");
+}
+
+
+} // test namespace
+
+/* vim: set noet fenc=utf-8 ff=dos sts=0 sw=4 ts=4 : */

--- a/test/test_conversion_c2sql_varchar.cc
+++ b/test/test_conversion_c2sql_varchar.cc
@@ -85,6 +85,21 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi_jsonescape)
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]");
 }
 
+TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape_oct_len_ptr)
+{
+	prepareStatement();
+
+	SQLCHAR val[] = "START_{xxx}=\"yyy\"\r__END";
+	SQLLEN octet_len = strlen((char *)val);
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+			SQL_VARCHAR, /*size*/35, /*decdigits*/0, val, sizeof(val),
+			&octet_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"KEYWORD\", "
+		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]");
+}
+
 /* note: test name used in test */
 TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape)
 {
@@ -113,6 +128,21 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_jsonescape)
 
 	assertRequest("[{\"type\": \"KEYWORD\", "
 		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}]");
+}
+
+TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape_oct_len_ptr)
+{
+	prepareStatement();
+
+	SQLWCHAR val[] = L"äöüÄÖÜ";
+	SQLLEN octet_len = SQL_NTSL;
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+			SQL_VARCHAR, /*size*/35, /*decdigits*/0, val, sizeof(val),
+			&octet_len);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"KEYWORD\", "
+		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}]");
 }
 
 /* note: test name used in test */


### PR DESCRIPTION
This PR fixes the length handling of received wide-char strings as
parameters: the indicator-length pointer of the API call provides the
octet count, so the lenght needs to be divided by wide-char size.

Besides a couple of tests for the fix, the PR adds a new test suite on
null generation (both of non-NULL and NULL types).