### PR TITLE
SQLNumParams now counts parameter markers

### DIFF
--- a/driver/defs.h
+++ b/driver/defs.h
@@ -55,7 +55,7 @@
 #define ESODBC_CATALOG_TERM			"catalog"
 #define ESODBC_TABLE_TERM			"table"
 #define ESODBC_SCHEMA_TERM			"schema"
-#define ESODBC_PARAM_MARKER			"?"
+#define ESODBC_PARAM_MARKER			'?'
 
 /* maximum identifer length: match ES/Lucene byte max */
 #define ESODBC_MAX_IDENTIFIER_LEN		SHRT_MAX

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -14,9 +14,6 @@
 #include "catalogue.h"
 #include "tinycbor.h"
 
-//#include "elasticodbc_export.h"
-//#define SQL_API	ELASTICODBC_EXPORT SQL_API
-
 
 #define RET_NOT_IMPLEMENTED(hnd) \
 	do { \

--- a/driver/util.h
+++ b/driver/util.h
@@ -274,7 +274,7 @@ SQLRETURN write_wstr(SQLHANDLE hnd, SQLWCHAR *dest, wstr_st *src,
 	SQLSMALLINT /*B*/avail, SQLSMALLINT /*B*/*usedp);
 
 /*
- * Converts a wide string to a UTF-8 MB, allocating the necessary space.
+ * Converts a UTF-16 wide string to a UTF-8 MB, allocating the necessary space.
  * The \0 is allocated and written, even if not present in source string, but
  * only counted in output string if counted in input one.
  * If 'dst' is null, the destination is also going to be allocate (collated
@@ -283,6 +283,9 @@ SQLRETURN write_wstr(SQLHANDLE hnd, SQLWCHAR *dest, wstr_st *src,
  * Returns NULL on error.
  */
 cstr_st TEST_API *wstr_to_utf8(wstr_st *src, cstr_st *dst);
+
+/* the inverse of wstr_to_utf8(). */
+wstr_st TEST_API *utf8_to_wstr(cstr_st *src, wstr_st *dst);
 
 /* Escape `%`, `_`, `\` characters in 'src'.
  * If not 'force'-d, the escaping will stop on detection of pre-existing

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -213,6 +213,12 @@ void ConnectedDBC::prepareStatement()
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 }
 
+void ConnectedDBC::prepareStatement(const SQLWCHAR *sql)
+{
+	ret = ATTACH_SQL(stmt, sql, wcslen(sql));
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+}
+
 void ConnectedDBC::prepareStatement(const SQLWCHAR *sql,
     const char *jsonAnswer)
 {

--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -57,6 +57,8 @@ class ConnectedDBC {
 	// use the test name as SQL (for faster logs lookup)
 	void prepareStatement();
 	// use an actual SQL statement (if it might be processed)
+	void prepareStatement(const SQLWCHAR *sql);
+	// use an actual SQL statement (if it might be processed)
 	void prepareStatement(const SQLWCHAR *sql, const char *jsonAnswer);
 	// use test name as SQL and attach given answer
 	void prepareStatement(const char *jsonAnswer);

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -105,6 +105,24 @@ TEST_F(Util, wstr_to_utf8_no_nts) {
 	free(dst.str);
 }
 
+TEST_F(Util, utf8_to_wstr_unicode) {
+#undef SRC_STR
+#undef SRC_AID
+#define SRC_STR	"XäXüXßX"
+#define SRC_AID	"X\xC3\xA4X\xC3\xBCX\xC3\x9FX"
+	wstr_st src = WSTR_INIT(SRC_STR);
+	cstr_st dst_mb;
+	wstr_st dst_wc;
+
+	ASSERT_EQ(&dst_mb, wstr_to_utf8(&src, &dst_mb));
+	ASSERT_EQ(&dst_wc, utf8_to_wstr(&dst_mb, &dst_wc));
+	ASSERT_STREQ((wchar_t *)src.str, (wchar_t *)dst_wc.str);
+	free(dst_mb.str);
+	free(dst_wc.str);
+}
+
+
+
 TEST_F(Util, ascii_c2w2c)
 {
 #undef SRC_STR


### PR DESCRIPTION
This PR adds an simple counter of the parameter markers within an
attached SQL statement.

While a correct and complete implementation would require in our case
sending the statement to the server for parameter analysis, this simple
implementation should work for most cases where the application simply
wants to validate the number of user-provided paramters number against
the number of markers in the statement.