### PR TITLE
Fix handling of size with DATE parameters

### DIFF
--- a/driver/convert.c
+++ b/driver/convert.c
@@ -4296,8 +4296,8 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 			 * needs to be zeroed. */
 			if (colsize) {
 				if (colsize != DATE_TEMPLATE_LEN) {
-					ERRH(stmt, "invalid column size value: %llu; allowed: %d.",
-						colsize, DATE_TEMPLATE_LEN);
+					ERRH(stmt, "invalid column size value: %llu; allowed: "
+						"%zu.", colsize, DATE_TEMPLATE_LEN);
 					RET_HDIAGS(stmt, SQL_STATE_HY104);
 				}
 				colsize += /* ` `/`T` */1 + TIME_TEMPLATE_LEN(0);

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -4285,7 +4285,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 				if (colsize < TIME_TEMPLATE_LEN(0) ||
 					colsize == TIME_TEMPLATE_LEN(1) - 1 /* `:ss.`*/) {
 					ERRH(stmt, "invalid column size value: %llu; allowed: "
-						"8 or greater than 9");
+						"8 or 9 + fractions count.", colsize);
 					RET_HDIAGS(stmt, SQL_STATE_HY104);
 				}
 				colsize += DATE_TEMPLATE_LEN + /* ` `/`T` */1;
@@ -4297,7 +4297,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 			if (colsize) {
 				if (colsize != DATE_TEMPLATE_LEN) {
 					ERRH(stmt, "invalid column size value: %llu; allowed: %d.",
-						DATE_TEMPLATE_LEN);
+						colsize, DATE_TEMPLATE_LEN);
 					RET_HDIAGS(stmt, SQL_STATE_HY104);
 				}
 				colsize += /* ` `/`T` */1 + TIME_TEMPLATE_LEN(0);
@@ -4312,7 +4312,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 			if (colsize && (colsize < TIMESTAMP_NOSEC_TEMPLATE_LEN ||
 					colsize == 17 || colsize == 18)) {
 				ERRH(stmt, "invalid column size value: %llu; allowed: "
-					"16, 19, 20+f.", colsize);
+					"16, 19 or 20 + fractions count.", colsize);
 				RET_HDIAGS(stmt, SQL_STATE_HY104);
 			}
 			break;

--- a/driver/util.h
+++ b/driver/util.h
@@ -350,6 +350,8 @@ char *cstr_hex_dump(const cstr_st *buff);
 	(sizeof("hh:mm:ss") - /*\0*/1 + /*'.'*/!!prec + prec)
 #define TIMESTAMP_TEMPLATE_LEN(prec)	\
 	(DATE_TEMPLATE_LEN + /*' '*/1 + TIME_TEMPLATE_LEN(prec))
+#define TIMESTAMP_NOSEC_TEMPLATE_LEN	\
+	(DATE_TEMPLATE_LEN + /*' '*/1 + sizeof("hh:mm") - /*\0*/1)
 
 
 #endif /* __UTIL_H__ */

--- a/test/test_conversion_c2sql_date.cc
+++ b/test/test_conversion_c2sql_date.cc
@@ -36,6 +36,18 @@ TEST_F(ConvertC2SQL_Date, Date2Date)
 		"\"value\": \"1234-12-23T00:00:00Z\"}]");
 }
 
+TEST_F(ConvertC2SQL_Date, CStr_Date2Date_size10)
+{
+	SQLCHAR val[] = "2000-01-01"; // treated as utc, since apply_tz==FALSE
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+			SQL_TYPE_DATE, /*size*/10, /*decdigits*/0, val, sizeof(val),
+			/*IndLen*/NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"DATE\", "
+		"\"value\": \"2000-01-01T00:00:00Z\"}]");
+}
+
 TEST_F(ConvertC2SQL_Date, CStr_Date2Date)
 {
 	SQLCHAR val[] = "2000-01-01"; // treated as utc, since apply_tz==FALSE
@@ -93,6 +105,18 @@ TEST_F(ConvertC2SQL_Date, WStr_Timestamp2Date)
 	SQLWCHAR val[] = L"1234-12-23T12:34:56.7890123Z";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
 			SQL_TYPE_DATE, /*size*/0, /*decdigits*/0, val, sizeof(val),
+			/*IndLen*/NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	assertRequest("[{\"type\": \"DATE\", "
+		"\"value\": \"1234-12-23T00:00:00Z\"}]");
+}
+
+TEST_F(ConvertC2SQL_Date, WStr_Timestamp2Date_size10)
+{
+	SQLWCHAR val[] = L"1234-12-23T12:34:56.7890123Z";
+	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+			SQL_TYPE_DATE, /*size*/10, /*decdigits*/0, val, sizeof(val),
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 

--- a/test/test_conversion_c2sql_time.cc
+++ b/test/test_conversion_c2sql_time.cc
@@ -75,11 +75,11 @@ TEST_F(ConvertC2SQL_Time, WStr_Timestamp2Time_colsize_16)
 {
 	SQLWCHAR val[] = L"1234-12-23T12:34:56.7890123Z";
 	ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-			SQL_TYPE_TIME, /*size*/16, /*decdigits*/0, val, sizeof(val),
+			SQL_TYPE_TIME, /*size*/8, /*decdigits*/0, val, sizeof(val),
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"TIME\", \"value\": \"12:34Z\"}]");
+	assertRequest("[{\"type\": \"TIME\", \"value\": \"12:34:56Z\"}]");
 }
 
 /* note: test name used in test */


### PR DESCRIPTION
This PR fixes the handling of the columns size of the DATE type parameters.

The previous implementation always expected the size of an ISO8601
timestamp, since DATE and TIME vals area ultimately parsed as a
timestamp. However the column size was passed through unchanged. With
this PR, the size is read as passed in by the application and
adjusted as needed.