### PR TITLE
Add dropdown to select data encapsulation format

### DIFF
--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
@@ -75,6 +75,8 @@ namespace EsOdbcDsnEditor
             this.textLogDirectoryPath = new System.Windows.Forms.TextBox();
             this.labelLogDirectory = new System.Windows.Forms.Label();
             this.pageMisc = new System.Windows.Forms.TabPage();
+            this.comboBoxDataEncoding = new System.Windows.Forms.ComboBox();
+            this.labelDataEncoding = new System.Windows.Forms.Label();
             this.checkBoxAutoEscapePVA = new System.Windows.Forms.CheckBox();
             this.comboBoxFloatsFormat = new System.Windows.Forms.ComboBox();
             this.labelFloatsFormat = new System.Windows.Forms.Label();
@@ -114,6 +116,7 @@ namespace EsOdbcDsnEditor
             this.toolTipAutoEscapePVA = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipMultiFieldLenient = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipIndexIncludeFrozen = new System.Windows.Forms.ToolTip(this.components);
+            this.toolTipDataEncoding = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.header)).BeginInit();
             this.groupSSL.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownPort)).BeginInit();
@@ -361,8 +364,8 @@ namespace EsOdbcDsnEditor
             // 
             this.tabConfiguration.Controls.Add(this.pageBasic);
             this.tabConfiguration.Controls.Add(this.pageSecurity);
-            this.tabConfiguration.Controls.Add(this.pageLogging);
             this.tabConfiguration.Controls.Add(this.pageMisc);
+            this.tabConfiguration.Controls.Add(this.pageLogging);
             this.tabConfiguration.Location = new System.Drawing.Point(17, 74);
             this.tabConfiguration.Name = "tabConfiguration";
             this.tabConfiguration.SelectedIndex = 0;
@@ -550,6 +553,8 @@ namespace EsOdbcDsnEditor
             // 
             // pageMisc
             // 
+            this.pageMisc.Controls.Add(this.comboBoxDataEncoding);
+            this.pageMisc.Controls.Add(this.labelDataEncoding);
             this.pageMisc.Controls.Add(this.checkBoxAutoEscapePVA);
             this.pageMisc.Controls.Add(this.comboBoxFloatsFormat);
             this.pageMisc.Controls.Add(this.labelFloatsFormat);
@@ -570,6 +575,28 @@ namespace EsOdbcDsnEditor
             this.pageMisc.TabIndex = 3;
             this.pageMisc.Text = "Misc";
             this.pageMisc.UseVisualStyleBackColor = true;
+            // 
+            // comboBoxDataEncoding
+            // 
+            this.comboBoxDataEncoding.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxDataEncoding.FormattingEnabled = true;
+            this.comboBoxDataEncoding.Items.AddRange(new object[] {
+            "JSON",
+            "CBOR"});
+            this.comboBoxDataEncoding.Location = new System.Drawing.Point(182, 155);
+            this.comboBoxDataEncoding.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.comboBoxDataEncoding.Name = "comboBoxDataEncoding";
+            this.comboBoxDataEncoding.Size = new System.Drawing.Size(108, 24);
+            this.comboBoxDataEncoding.TabIndex = 31;
+            // 
+            // labelDataEncoding
+            // 
+            this.labelDataEncoding.AutoSize = true;
+            this.labelDataEncoding.Location = new System.Drawing.Point(24, 158);
+            this.labelDataEncoding.Name = "labelDataEncoding";
+            this.labelDataEncoding.Size = new System.Drawing.Size(104, 17);
+            this.labelDataEncoding.TabIndex = 30;
+            this.labelDataEncoding.Text = "Data encoding:";
             // 
             // checkBoxAutoEscapePVA
             // 
@@ -601,7 +628,7 @@ namespace EsOdbcDsnEditor
             // labelFloatsFormat
             // 
             this.labelFloatsFormat.AutoSize = true;
-            this.labelFloatsFormat.Location = new System.Drawing.Point(66, 122);
+            this.labelFloatsFormat.Location = new System.Drawing.Point(24, 122);
             this.labelFloatsFormat.Name = "labelFloatsFormat";
             this.labelFloatsFormat.Size = new System.Drawing.Size(94, 17);
             this.labelFloatsFormat.TabIndex = 27;
@@ -850,6 +877,9 @@ namespace EsOdbcDsnEditor
 		private System.Windows.Forms.ToolTip toolTipAutoEscapePVA;
 		private System.Windows.Forms.ToolTip toolTipMultiFieldLenient;
 		private System.Windows.Forms.ToolTip toolTipIndexIncludeFrozen;
+		private System.Windows.Forms.ComboBox comboBoxDataEncoding;
+		private System.Windows.Forms.Label labelDataEncoding;
+		private System.Windows.Forms.ToolTip toolTipDataEncoding;
 	}
 }
 

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -152,11 +152,12 @@ namespace EsOdbcDsnEditor
 			toolTipLogDirectoryPath.SetToolTip(textLogDirectoryPath, "Specify which directory to write the log files in.");
 			toolTipLogLevel.SetToolTip(comboLogLevel, "Configure the verbosity of the logs.");
 
-			// Logging Panel
+			// Misc Panel
 			numericUpDownTimeout.Text = Builder.ContainsKey("Timeout") ? Builder["Timeout"].ToString().StripBraces() : "0";
 			numericUpDownFetchSize.Text = Builder.ContainsKey("MaxFetchSize") ? Builder["MaxFetchSize"].ToString().StripBraces() : "1000";
 			numericUpDownBodySize.Text = Builder.ContainsKey("MaxBodySizeMB") ? Builder["MaxBodySizeMB"].ToString().StripBraces() : "100";
 			comboBoxFloatsFormat.Text = Builder.ContainsKey("ScientificFloats") ? Builder["ScientificFloats"].ToString().StripBraces() : "default";
+			comboBoxDataEncoding.Text = Builder.ContainsKey("Packing") ? Builder["Packing"].ToString() : "JSON";
 
 			string[] noes = {"no", "false", "0"};
 			checkBoxFollowRedirects.Checked = !noes.Contains(Builder.ContainsKey("Follow") ? Builder["Follow"].ToString().StripBraces() : "yes");
@@ -169,6 +170,7 @@ namespace EsOdbcDsnEditor
 			toolTipFetchSize.SetToolTip(numericUpDownFetchSize, "The maximum number of rows that Elasticsearch SQL server should send the driver for one page.");
 			toolTipBodySize.SetToolTip(numericUpDownBodySize, "The maximum number of megabytes that the driver will accept for one page.");
 			toolTipFloatsFormat.SetToolTip(comboBoxFloatsFormat, "How should the floating point numbers be printed, when these are converted to string by the driver.");
+			toolTipDataEncoding.SetToolTip(comboBoxDataEncoding, "How should the data between the server and the driver be encoded as.");
 			toolTipFollowRedirects.SetToolTip(checkBoxFollowRedirects, "Should the driver follow HTTP redirects of the requests to the server?");
 			toolTipApplyTZ.SetToolTip(checkBoxApplyTZ, "Should the driver use machine's local timezone? The default is UTC.");
 			toolTipAutoEscapePVA.SetToolTip(checkBoxAutoEscapePVA, "Should the driver auto-escape the pattern-value arguments?");
@@ -280,6 +282,7 @@ namespace EsOdbcDsnEditor
 			Builder["MaxFetchSize"] = numericUpDownFetchSize.Text;
 			Builder["MaxBodySizeMB"] = numericUpDownBodySize.Text;
 			Builder["ScientificFloats"] = comboBoxFloatsFormat.Text;
+			Builder["Packing"] = comboBoxDataEncoding.Text;
 			Builder["Follow"] = checkBoxFollowRedirects.Checked ? "true" : "false";
 			Builder["ApplyTZ"] = checkBoxApplyTZ.Checked ? "true" : "false";
 			Builder["AutoEscapePVA"] = checkBoxAutoEscapePVA.Checked ? "true" : "false";

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
@@ -2834,6 +2834,9 @@
   <metadata name="toolTipIndexIncludeFrozen.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>617, 213</value>
   </metadata>
+  <metadata name="toolTipDataEncoding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>854, 213</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>314</value>
   </metadata>


### PR DESCRIPTION
This PR adds the configuration to the editor form to allow selecting
between JSON and CBOR as data encapsulation.

The text labels on the Misc panel have been left aligned.

Also the Logging and Misc pannels have been swapped, to have Logging
ever so slightly easier to spot.