### PR TITLE
Trim whitespace from certain DSN fields

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -949,8 +949,7 @@ static BOOL decode_cloud_id(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 	if (Curl_base64_decode(buff, &dec, &len) != CURLE_OK) {
 		ERRH(dbc, "failed to decode B64 part of  Cloud ID: [%zu] `" LWPDL "`.",
 			attrs->cloud_id.cnt, LWSTR(&attrs->cloud_id));
-		SET_HDIAG(dbc, SQL_STATE_HY000, "Invalid Base64 encoding in Cloud ID "
-			"parameter", 0);
+		SET_HDIAG(dbc, SQL_STATE_HY000, "Invalid Cloud ID parameter", 0);
 		return FALSE;
 	}
 	DBGH(dbc, "Cloud ID decoded to: [%zu] `" LCPDL "`.", len, len, dec);

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -258,10 +258,13 @@ namespace EsOdbcDsnEditor
 			// Basic Panel
 			Builder["dsn"] = textName.Text;
 			Builder["description"] = textDescription.Text;
-			Builder["uid"] = textUsername.Text;
+			// https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html#security-api-put-user-path-params :
+			// "Leading or trailing whitespace is not allowed." -> it is more likely that a user will insert a
+			// (trailing) white space by mistake than intentionally trying to set it.
+			Builder["uid"] = textUsername.Text.Trim();
 			Builder["pwd"] = textPassword.Text;
-			Builder["cloudid"] = "{" + textCloudID.Text.StripBraces() + "}";
-			Builder["server"] = textHostname.Text;
+			Builder["cloudid"] = "{" + textCloudID.Text.StripBraces().Trim() + "}";
+			Builder["server"] = textHostname.Text.Trim();
 			Builder["port"] = numericUpDownPort.Text;
 
 			// Security Panel


### PR DESCRIPTION
Trim whitespace from `Cloud ID`, `User` and `Hostname` field values before
submitting these to the driver.
(WS is likely to be inserted if copy&pasting these values.)

Also, rephrase the error message presented to the user in case the `Cloud
ID` is incorrect.