### PR TITLE
Sign DLL files to be added into the MSI

### DIFF
--- a/installer/build/scripts/Build.fsx
+++ b/installer/build/scripts/Build.fsx
@@ -161,6 +161,15 @@ module Builder =
         unzipFile (zipFile, buildDir)
         tracefn "Unzipped zip file in %s" zipFile
 
+        // sign every DLL to be part of the MSI
+        let unzippedDir = Regex.Replace(zipFile, "(^.*)\.zip$", "$1/")
+        let dllFiles = unzippedDir
+                        |> directoryInfo
+                        |> filesInDirMatching ("*.dll")
+                        |> Seq.map (fun f -> f.FullName)
+        for dllFile in dllFiles do
+            Sign dllFile
+
         let exitCode = ExecProcess (fun info ->
                          info.FileName <- sprintf "%sInstaller" MsiBuildDir
                          info.WorkingDirectory <- MsiDir


### PR DESCRIPTION
So far only the MSI had been considered for signing. This commit adds
the logic to also sign the DLL files that are going to be packed into
the MSI.

The PR adds the code to find all the DLL files within the directory
unpackaged from the ZIP file produced by the build, then sign them with
same function used to sign the MSI file.