### PR TITLE
DSN editor: add option for payload compression

### DIFF
--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
@@ -117,6 +117,9 @@ namespace EsOdbcDsnEditor
             this.toolTipMultiFieldLenient = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipIndexIncludeFrozen = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipDataEncoding = new System.Windows.Forms.ToolTip(this.components);
+            this.labelDataCompression = new System.Windows.Forms.Label();
+            this.comboBoxDataCompression = new System.Windows.Forms.ComboBox();
+            this.toolTipDataCompression = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.header)).BeginInit();
             this.groupSSL.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownPort)).BeginInit();
@@ -469,6 +472,8 @@ namespace EsOdbcDsnEditor
             // 
             // pageMisc
             // 
+            this.pageMisc.Controls.Add(this.comboBoxDataCompression);
+            this.pageMisc.Controls.Add(this.labelDataCompression);
             this.pageMisc.Controls.Add(this.comboBoxDataEncoding);
             this.pageMisc.Controls.Add(this.labelDataEncoding);
             this.pageMisc.Controls.Add(this.checkBoxAutoEscapePVA);
@@ -760,6 +765,29 @@ namespace EsOdbcDsnEditor
             this.labelLogDirectory.TabIndex = 16;
             this.labelLogDirectory.Text = "Log Directory:";
             // 
+            // labelDataCompression
+            // 
+            this.labelDataCompression.AutoSize = true;
+            this.labelDataCompression.Location = new System.Drawing.Point(24, 198);
+            this.labelDataCompression.Name = "labelDataCompression";
+            this.labelDataCompression.Size = new System.Drawing.Size(126, 17);
+            this.labelDataCompression.TabIndex = 31;
+            this.labelDataCompression.Text = "Data compression:";
+            // 
+            // comboBoxDataCompression
+            // 
+            this.comboBoxDataCompression.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxDataCompression.FormattingEnabled = true;
+            this.comboBoxDataCompression.Items.AddRange(new object[] {
+            "auto",
+            "on",
+            "off"});
+            this.comboBoxDataCompression.Location = new System.Drawing.Point(182, 191);
+            this.comboBoxDataCompression.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.comboBoxDataCompression.Name = "comboBoxDataCompression";
+            this.comboBoxDataCompression.Size = new System.Drawing.Size(108, 24);
+            this.comboBoxDataCompression.TabIndex = 32;
+            // 
             // DsnEditorForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -880,6 +908,9 @@ namespace EsOdbcDsnEditor
 		private System.Windows.Forms.ComboBox comboBoxDataEncoding;
 		private System.Windows.Forms.Label labelDataEncoding;
 		private System.Windows.Forms.ToolTip toolTipDataEncoding;
+		private System.Windows.Forms.ComboBox comboBoxDataCompression;
+		private System.Windows.Forms.Label labelDataCompression;
+		private System.Windows.Forms.ToolTip toolTipDataCompression;
 	}
 }
 

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -158,6 +158,7 @@ namespace EsOdbcDsnEditor
 			numericUpDownBodySize.Text = Builder.ContainsKey("MaxBodySizeMB") ? Builder["MaxBodySizeMB"].ToString().StripBraces() : "100";
 			comboBoxFloatsFormat.Text = Builder.ContainsKey("ScientificFloats") ? Builder["ScientificFloats"].ToString().StripBraces() : "default";
 			comboBoxDataEncoding.Text = Builder.ContainsKey("Packing") ? Builder["Packing"].ToString() : "JSON";
+			comboBoxDataCompression.Text = Builder.ContainsKey("Compression") ? Builder["Compression"].ToString() : "auto";
 
 			string[] noes = {"no", "false", "0"};
 			checkBoxFollowRedirects.Checked = !noes.Contains(Builder.ContainsKey("Follow") ? Builder["Follow"].ToString().StripBraces() : "yes");
@@ -171,6 +172,7 @@ namespace EsOdbcDsnEditor
 			toolTipBodySize.SetToolTip(numericUpDownBodySize, "The maximum number of megabytes that the driver will accept for one page.");
 			toolTipFloatsFormat.SetToolTip(comboBoxFloatsFormat, "How should the floating point numbers be printed, when these are converted to string by the driver.");
 			toolTipDataEncoding.SetToolTip(comboBoxDataEncoding, "How should the data between the server and the driver be encoded as.");
+			toolTipDataCompression.SetToolTip(comboBoxDataCompression, "Should the data between the server and the driver be compressed?");
 			toolTipFollowRedirects.SetToolTip(checkBoxFollowRedirects, "Should the driver follow HTTP redirects of the requests to the server?");
 			toolTipApplyTZ.SetToolTip(checkBoxApplyTZ, "Should the driver use machine's local timezone? The default is UTC.");
 			toolTipAutoEscapePVA.SetToolTip(checkBoxAutoEscapePVA, "Should the driver auto-escape the pattern-value arguments?");
@@ -286,6 +288,7 @@ namespace EsOdbcDsnEditor
 			Builder["MaxBodySizeMB"] = numericUpDownBodySize.Text;
 			Builder["ScientificFloats"] = comboBoxFloatsFormat.Text;
 			Builder["Packing"] = comboBoxDataEncoding.Text;
+			Builder["Compression"] = comboBoxDataCompression.Text;
 			Builder["Follow"] = checkBoxFollowRedirects.Checked ? "true" : "false";
 			Builder["ApplyTZ"] = checkBoxApplyTZ.Checked ? "true" : "false";
 			Builder["AutoEscapePVA"] = checkBoxAutoEscapePVA.Checked ? "true" : "false";

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
@@ -2837,6 +2837,9 @@
   <metadata name="toolTipDataEncoding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>854, 213</value>
   </metadata>
+  <metadata name="toolTipDataCompression.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1046, 215</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>314</value>
   </metadata>


### PR DESCRIPTION
This PR adds a drop-down to allow the payload compression strategy
(one value in: "auto", "on", "off").
The option is encoded in the DSN as the attribute "Compression".