### PR TITLE
Fix test: force JSON format for tests

### DIFF
--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -100,7 +100,7 @@ extern "C" {
 }"
 
 /* minimal, valid connection string */
-#define CONNECT_STRING L"Driver=ElasticODBC"
+#define CONNECT_STRING L"Driver=ElasticODBC;Packing=JSON;"
 
 class ConnectedDBC {
 	protected:


### PR DESCRIPTION
This PR fixes the integration tests past switching to CBOR by
default for the REST body format (#201): the integration tests make use of the
(textual) JSON format, which needs to be enabled in the connection
string used by the simulated connection.