### PR TITLE
Fix: init var that's otherwise accessed uninit'd

### DIFF
--- a/driver/convert.c
+++ b/driver/convert.c
@@ -4387,6 +4387,7 @@ SQLRETURN c2sql_date_time(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		return ret;
 	}
 
+	format = 0;
 	/*INDENT-OFF*/
 	switch ((ctype = get_rec_c_type(arec, irec))) {
 		case SQL_C_CHAR:


### PR DESCRIPTION
This PR initialises a variable ("format") that can be read
uninitialised. There are no negative manifestations of this issue.

---
The var carries the type of time format that has been detected when
parsing a string input value, which would subsequently be converted to
a TIME/DATE/TIMESTAMP data type. In case the source is a string
representing a TIMESTAMP and the destination a DATE, the representation
of the destination is obtained from the original input, by zero-ing the
time part (since this is how DATEs are represented in ES/SQL) and the
"format" var decides, in a disjunction with another variable, on this
action.

In case the source is of the type DATE and the destination also a DATE,
the "format" var would not be set, but its value read. In the case the
random value the var can take matches the condition, a zero'ing of an
already zero'd string would happen, with no other side-effect.