### PR TITLE
Fix: allow (re)setting the current catalog

### DIFF
--- a/driver/catalogue.c
+++ b/driver/catalogue.c
@@ -94,6 +94,36 @@ SQLRETURN EsSQLStatisticsW(
 #	undef STATISTICS_EMPTY
 }
 
+BOOL TEST_API set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog)
+{
+	if (dbc->catalog.cnt) {
+		DBGH(dbc, "catalog already set to `" LWPDL "`.", LWSTR(&dbc->catalog));
+		if (! EQ_WSTR(&dbc->catalog, catalog)) {
+			/* this should never happen, as cluster's name is not updateable
+			 * on the fly. */
+			ERRH(dbc, "overwriting previously set catalog value!");
+			free(dbc->catalog.str);
+			dbc->catalog.str = NULL;
+			dbc->catalog.cnt = 0;
+		} else {
+			return FALSE;
+		}
+	}
+	if (! catalog->cnt) {
+		WARNH(dbc, "attempting to set catalog name to empty value.");
+		return FALSE;
+	}
+	if (! (dbc->catalog.str = malloc((catalog->cnt + 1) * sizeof(SQLWCHAR)))) {
+		ERRNH(dbc, "OOM for %zu wchars.", catalog->cnt + 1);
+		return FALSE;
+	}
+	wmemcpy(dbc->catalog.str, catalog->str, catalog->cnt);
+	dbc->catalog.str[catalog->cnt] = L'\0';
+	dbc->catalog.cnt = catalog->cnt;
+	INFOH(dbc, "current catalog name: `" LWPDL "`.", LWSTR(&dbc->catalog));
+
+	return TRUE;
+}
 
 /* writes into 'dest', of size 'room', the current requested attr. of 'dbc'.
  * returns negative on error, or the char count written otherwise */
@@ -174,6 +204,9 @@ SQLSMALLINT fetch_server_attr(esodbc_dbc_st *dbc, SQLINTEGER attr_id,
 			attr_val.cnt = ind_len / sizeof(*buff);
 			/* 0-term room left out when binding */
 			buff[attr_val.cnt] = L'\0'; /* write_wstr() expects the 0-term */
+		}
+		if (attr_id == SQL_ATTR_CURRENT_CATALOG) {
+			set_current_catalog(dbc, &attr_val);
 		}
 	}
 	DBGH(dbc, "attribute %ld value: `" LWPDL "`.", attr_id, LWSTR(&attr_val));

--- a/driver/catalogue.h
+++ b/driver/catalogue.h
@@ -13,6 +13,7 @@
 
 SQLSMALLINT fetch_server_attr(esodbc_dbc_st *dbc, SQLINTEGER attr_id,
 	SQLWCHAR *dest, SQLSMALLINT room);
+BOOL TEST_API set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog);
 
 
 SQLRETURN EsSQLStatisticsW(

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -3098,7 +3098,7 @@ SQLRETURN EsSQLDisconnect(SQLHDBC ConnectionHandle)
  * time. But there's no client reported yet setting a catalog value before
  * connecting. */
 static SQLRETURN check_catalog_name(esodbc_dbc_st *dbc, SQLWCHAR *name,
-		SQLINTEGER len)
+	SQLINTEGER len)
 {
 	wstr_st catalog;
 	catalog.str = name;

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1528,6 +1528,13 @@ void cleanup_dbc(esodbc_dbc_st *dbc)
 		dbc->srv_ver.string.str = NULL;
 		dbc->srv_ver.string.cnt = 0;
 	}
+	if (dbc->catalog.str) {
+		free(dbc->catalog.str);
+		dbc->catalog.str = NULL;
+		dbc->catalog.cnt = 0;
+	} else {
+		assert(dbc->catalog.cnt == 0);
+	}
 
 	assert(dbc->abuff == NULL);
 	cleanup_curl(dbc);
@@ -3082,7 +3089,37 @@ SQLRETURN EsSQLDisconnect(SQLHDBC ConnectionHandle)
 	return SQL_SUCCESS;
 }
 
-
+/* ES/SQL doesn't support catalogs (yet). This function checks that a
+ * previously retrieved (and cached) catalog value is the same with what the
+ * app currently tries to set it to.
+ * Ideally, the app provided value would be cached here too (as per the spec:
+ * "SQL_ATTR_CURRENT_CATALOG can be set before or after connecting"), in case
+ * there's no connection "established" yet and checked at "establishment"
+ * time. But there's no client reported yet setting a catalog value before
+ * connecting. */
+static SQLRETURN check_catalog_name(esodbc_dbc_st *dbc, SQLWCHAR *name,
+		SQLINTEGER len)
+{
+	wstr_st catalog;
+	catalog.str = name;
+	if (len < 0) {
+		catalog.cnt = wcslen(name);
+	} else {
+		catalog.cnt = (size_t)len;
+	}
+	if (! EQ_WSTR(&dbc->catalog, &catalog)) {
+		if (! dbc->catalog.cnt) {
+			/* this will happen if the app tries to set a value that it
+			 * discovered over a different connection.
+			 * TODO on a first reported issue. */
+			WARNH(dbc, "connection's current catalog not yet set!");
+		}
+		ERRH(dbc, "setting catalog name not supported.");
+		RET_HDIAGS(dbc, SQL_STATE_HYC00);
+	}
+	WARNH(dbc, "ignoring attempt to set the current catalog.");
+	return SQL_SUCCESS;
+}
 
 /*
  * https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/unicode-drivers :
@@ -3222,8 +3259,7 @@ SQLRETURN EsSQLSetConnectAttrW(
 				/* string should be 0-term'd */
 				0 <= StringLength ? StringLength : SHRT_MAX,
 				(SQLWCHAR *)Value);
-			ERRH(dbc, "setting catalog name not supported.");
-			RET_HDIAGS(dbc, SQL_STATE_HYC00);
+			return check_catalog_name(dbc, (SQLWCHAR *)Value, StringLength);
 
 		case SQL_ATTR_TRACE:
 		case SQL_ATTR_TRACEFILE: /* DM-only */

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -131,9 +131,10 @@ typedef struct struct_dbc {
 
 	wstr_st dsn; /* data source name SQLGetInfo(SQL_DATA_SOURCE_NAME) */
 	wstr_st server; /* ~ name; requested with SQLGetInfo(SQL_SERVER_NAME) */
+	wstr_st catalog; /* cached value; checked against if app setting it */
 	union {
 		wstr_st string; /* version: SQLGetInfo(SQL_DBMS_VER)  */
-		unsigned char checking; /* first letter of DSN config option */
+		unsigned char checking; /* first letter of DSN config option value */
 	} srv_ver; /* server version */
 	cstr_st url; /* SQL URL (posts) */
 	cstr_st close_url; /* SQL close URL (posts) */

--- a/test/test_driverconnect.cc
+++ b/test/test_driverconnect.cc
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 #include "connected_dbc.h"
 
-/*  */
 extern "C" {
 #include "catalogue.h" /* set_current_catalog() */
 }


### PR DESCRIPTION
This PR allows the application set the value of the current catalog attribute, in case this value is the same with what the driver had previously returned for this attribute.

Although Elasticsearch/SQL has no proper catalog support currently, this case should be supported as a safe use of the API.

This currently only works if the attribute had been retrieved before setting, on the same connection; specifically, it won't work when this would be set as a pre-connection attribute.

Closes #211.