### PR TITLE
Allow some statement attributes be used for a connection

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -3196,9 +3196,9 @@ SQLRETURN EsSQLSetConnectAttrW(
 			RET_HDIAGS(dbc, SQL_STATE_HY092);
 			break;
 
+		/* coalesce login, connection and query timeouts for a REST req. */
 		case SQL_ATTR_QUERY_TIMEOUT: /* stmt attr -- 2.x */
 			WARNH(dbc, "applying a statement as connection attribute (2.x?)");
-		/* coalesce login and connection timeouts for a REST req. */
 		case SQL_ATTR_CONNECTION_TIMEOUT:
 		case SQL_ATTR_LOGIN_TIMEOUT:
 			INFOH(dbc, "setting login/connection timeout: %lu",

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -3196,6 +3196,8 @@ SQLRETURN EsSQLSetConnectAttrW(
 			RET_HDIAGS(dbc, SQL_STATE_HY092);
 			break;
 
+		case SQL_ATTR_QUERY_TIMEOUT: /* stmt attr -- 2.x */
+			WARNH(dbc, "applying a statement as connection attribute (2.x?)");
 		/* coalesce login and connection timeouts for a REST req. */
 		case SQL_ATTR_CONNECTION_TIMEOUT:
 		case SQL_ATTR_LOGIN_TIMEOUT:
@@ -3244,10 +3246,17 @@ SQLRETURN EsSQLSetConnectAttrW(
 			RET_HDIAGS(DBCH(ConnectionHandle), SQL_STATE_HY092);
 #endif
 
+		case SQL_ATTR_MAX_ROWS: /* stmt attr -- 2.x app */
+			WARNH(dbc, "applying a statement as connection attribute (2.x?)");
+			DBGH(dbc, "setting max rows: %llu.", (SQLULEN)Value);
+			if ((SQLULEN)Value != 0) {
+				WARNH(dbc, "requested max_rows substituted with 0.");
+				RET_HDIAGS(dbc, SQL_STATE_01S02);
+			}
+			break;
+
 		default:
 			ERRH(dbc, "unknown Attribute: %d.", Attribute);
-			// FIXME: add the other attributes
-			FIXME;
 			RET_HDIAGS(dbc, SQL_STATE_HY092);
 	}
 


### PR DESCRIPTION
Allow two statment attributes be used on a connection handle.

This is in support of some 2.x applications that can make use of them.
- SQL_ATTR_MAX_ROWS: the value is reset to 0 if different, which is the
same behavior the driver has when the attribute is set on a statement;
- SQL_ATTR_QUERY_TIMEOUT: the attribute is applied; any statement
belonging to the affected connection can subsequently override the
value, so the support is safe.