### PR TITLE
Prepare the driver to work with newer server releases than its own

### DIFF
--- a/driver/defs.h
+++ b/driver/defs.h
@@ -122,8 +122,6 @@
 /* maximum DNS attribute value lenght (should be long enought to accomodate a
  * decently long FQ file path name) */
 #define ESODBC_DSN_MAX_ATTR_LEN			1024
-/* sample DSN name provisioned with the installation  */
-#define ESODBC_DSN_SAMPLE_NAME			"Elasticsearch ODBC Sample DSN"
 
 /* SQL plugin's REST endpoint for SQL */
 #define ELASTIC_SQL_PATH				"/_sql"
@@ -139,6 +137,8 @@
 #define ESODBC_DRIVER_VER	STR(DRV_VERSION) \
 	"(" STR(DRV_SRC_VER) "," STR(DRV_ENCODING) "," STR(DRV_BUILD_TYPE) ")"
 #define ESODBC_ELASTICSEARCH_NAME	"Elasticsearch"
+/* the driver will work with an ES node of this version and higher */
+#define ESODBC_MIN_ES_VER			"7.7.0"
 
 /*
  * Config defaults
@@ -176,8 +176,6 @@
 /* default of scientific floats printing */
 #define ESODBC_DEF_SCI_FLOATS		ESODBC_DSN_FLTS_DEF
 #define ESODBC_PWD_VAL_SUBST		"<redacted>"
-/* default version checking mode: strict, major, none (dbg only) */
-#define ESODBC_DEF_VERSION_CHECKING	ESODBC_DSN_VC_STRICT
 #define ESODBC_DEF_MFIELD_LENIENT	"true"
 #define ESODBC_DEF_ESC_PVA			"true"
 #define ESODBC_DEF_IDX_INC_FROZEN	"false"

--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -880,9 +880,6 @@ void assign_dsn_defaults(esodbc_dsn_attrs_st *attrs)
 	res |= assign_dsn_attr(attrs, &MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB),
 			&MK_WSTR(ESODBC_DEF_MAX_BODY_SIZE_MB),
 			/*overwrite?*/FALSE);
-	res |= assign_dsn_attr(attrs, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING),
-			&MK_WSTR(ESODBC_DEF_VERSION_CHECKING),
-			/*overwrite?*/FALSE);
 
 	res |= assign_dsn_attr(attrs,
 			&MK_WSTR(ESODBC_DSN_APPLY_TZ), &MK_WSTR(ESODBC_DEF_APPLY_TZ),

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -51,10 +51,6 @@
 #define ESODBC_DSN_CMPSS_AUTO		"auto"
 #define ESODBC_DSN_CMPSS_ON			"on"
 #define ESODBC_DSN_CMPSS_OFF		"off"
-/* VersionChecking values */
-#define ESODBC_DSN_VC_STRICT		"strict"
-#define ESODBC_DSN_VC_MAJOR			"major"
-#define ESODBC_DSN_VC_NONE			"none"
 /* Floats printing */
 #define ESODBC_DSN_FLTS_DEF			"default"
 #define ESODBC_DSN_FLTS_SCI			"scientific"

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -132,10 +132,7 @@ typedef struct struct_dbc {
 	wstr_st dsn; /* data source name SQLGetInfo(SQL_DATA_SOURCE_NAME) */
 	wstr_st server; /* ~ name; requested with SQLGetInfo(SQL_SERVER_NAME) */
 	wstr_st catalog; /* cached value; checked against if app setting it */
-	union {
-		wstr_st string; /* version: SQLGetInfo(SQL_DBMS_VER)  */
-		unsigned char checking; /* first letter of DSN config option value */
-	} srv_ver; /* server version */
+	wstr_st srv_ver; /* server version: SQLGetInfo(SQL_DBMS_VER) */
 	cstr_st url; /* SQL URL (posts) */
 	cstr_st close_url; /* SQL close URL (posts) */
 	cstr_st root_url; /* root URL (gets) */

--- a/driver/info.c
+++ b/driver/info.c
@@ -306,8 +306,8 @@ static SQLRETURN getinfo_dbms_product(
 					StringLengthPtr);
 		case SQL_DBMS_VER:
 			DBGH(dbc, "requested: DBMS version (`" LWPDL "`).",
-				LWSTR(&dbc->srv_ver.string));
-			return write_wstr(dbc, InfoValue, &dbc->srv_ver.string,
+				LWSTR(&dbc->srv_ver));
+			return write_wstr(dbc, InfoValue, &dbc->srv_ver,
 					BufferLength, StringLengthPtr);
 	}
 	*handled = FALSE;

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -2982,15 +2982,15 @@ static SQLRETURN statement_len_cbor(esodbc_stmt_st *stmt, size_t *enc_len,
 		/* "time_zone": "-05:45" */
 		bodylen += cbor_str_obj_len(sizeof(REQ_KEY_TIMEZONE) - 1);
 		bodylen += cbor_str_obj_len(tz_param.cnt); /* lax len */
-		*keys += 3; /* field_m._val., idx._inc._frozen, time_zone */
+		bodylen += cbor_str_obj_len(sizeof(REQ_KEY_VERSION) - 1);
+		bodylen += cbor_str_obj_len(version.cnt);
+		*keys += 4; /* field_m._val., idx._inc._frozen, time_zone, version */
 	}
 	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_MODE) - 1);
 	bodylen += cbor_str_obj_len(sizeof(REQ_VAL_MODE) - 1);
 	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_CLT_ID) - 1);
 	bodylen += cbor_str_obj_len(sizeof(REQ_VAL_CLT_ID) - 1);
-	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_VERSION) - 1);
-	bodylen += version.cnt;
-	*keys += 3; /* mode, client_id, version */
+	*keys += 2; /* mode, client_id */
 	/* TODO: request_/page_timeout */
 
 	*enc_len = bodylen;
@@ -3044,11 +3044,12 @@ static SQLRETURN statement_len_json(esodbc_stmt_st *stmt, size_t *outlen)
 		/* "time_zone": "-05:45" */
 		bodylen += sizeof(JSON_KEY_TIMEZONE) - 1;
 		bodylen += tz_param.cnt;
+		/* "version": */
+		bodylen += sizeof(JSON_KEY_VERSION) - 1;
+		bodylen += version.cnt + /* 2x`"` */2;
 	}
 	bodylen += sizeof(JSON_KEY_VAL_MODE) - 1; /* "mode": "ODBC" */
 	bodylen += sizeof(JSON_KEY_CLT_ID) - 1; /* "client_id": "odbcXX" */
-	bodylen += sizeof(JSON_KEY_VERSION) - 1; /* "version": */
-	bodylen += version.cnt + /* 2x`"` */2;
 	/* TODO: request_/page_timeout */
 	bodylen += 1; /* } */
 
@@ -3320,6 +3321,12 @@ static SQLRETURN serialize_to_cbor(esodbc_stmt_st *stmt, cstr_st *dest,
 		}
 		err = cbor_encode_text_string(&map, tz.str, tz.cnt);
 		FAIL_ON_CBOR_ERR(stmt, err);
+		/* version */
+		err = cbor_encode_text_string(&map, REQ_KEY_VERSION,
+				sizeof(REQ_KEY_VERSION) - 1);
+		FAIL_ON_CBOR_ERR(stmt, err);
+		err = cbor_encode_text_string(&map, version.str, version.cnt);
+		FAIL_ON_CBOR_ERR(stmt, err);
 	}
 	/* mode : ODBC */
 	err = cbor_encode_text_string(&map, REQ_KEY_MODE,
@@ -3334,12 +3341,6 @@ static SQLRETURN serialize_to_cbor(esodbc_stmt_st *stmt, cstr_st *dest,
 	FAIL_ON_CBOR_ERR(stmt, err);
 	err = cbor_encode_text_string(&map, REQ_VAL_CLT_ID,
 			sizeof(REQ_VAL_CLT_ID) - 1);
-	FAIL_ON_CBOR_ERR(stmt, err);
-	/* version */
-	err = cbor_encode_text_string(&map, REQ_KEY_VERSION,
-			sizeof(REQ_KEY_VERSION) - 1);
-	FAIL_ON_CBOR_ERR(stmt, err);
-	err = cbor_encode_text_string(&map, version.str, version.cnt);
 	FAIL_ON_CBOR_ERR(stmt, err);
 
 	err = cbor_encoder_close_container(&encoder, &map);
@@ -3443,6 +3444,13 @@ static SQLRETURN serialize_to_json(esodbc_stmt_st *stmt, cstr_st *dest)
 				sizeof(JSON_VAL_TIMEZONE_Z) - 1);
 			pos += sizeof(JSON_VAL_TIMEZONE_Z) - 1;
 		}
+		/* "version": ... */
+		memcpy(body + pos, JSON_KEY_VERSION, sizeof(JSON_KEY_VERSION) - 1);
+		pos += sizeof(JSON_KEY_VERSION) - 1;
+		body[pos ++] = '"';
+		memcpy(body + pos, version.str, version.cnt);
+		pos += version.cnt;
+		body[pos ++] = '"';
 	}
 	/* "mode": "ODBC" */
 	memcpy(body + pos, JSON_KEY_VAL_MODE, sizeof(JSON_KEY_VAL_MODE) - 1);
@@ -3450,13 +3458,6 @@ static SQLRETURN serialize_to_json(esodbc_stmt_st *stmt, cstr_st *dest)
 	/* "client_id": "odbcXX" */
 	memcpy(body + pos, JSON_KEY_CLT_ID, sizeof(JSON_KEY_CLT_ID) - 1);
 	pos += sizeof(JSON_KEY_CLT_ID) - 1;
-	/* "version": ... */
-	memcpy(body + pos, JSON_KEY_VERSION, sizeof(JSON_KEY_VERSION) - 1);
-	pos += sizeof(JSON_KEY_VERSION) - 1;
-	body[pos ++] = '"';
-	memcpy(body + pos, version.str, version.cnt);
-	pos += version.cnt;
-	body[pos ++] = '"';
 	body[pos ++] = '}';
 
 	/* check that the buffer hasn't been overrun. it can be used less than

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -138,6 +138,7 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define REQ_KEY_PAGE_TOUT		"page_timeout"
 #define REQ_KEY_MODE			"mode"
 #define REQ_KEY_CLT_ID			"client_id"
+#define REQ_KEY_VERSION			"version"
 #define REQ_KEY_MULTIVAL		"field_multi_value_leniency"
 #define REQ_KEY_IDX_FROZEN		"index_include_frozen"
 #define REQ_KEY_TIMEZONE		"time_zone"
@@ -166,6 +167,7 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 	REQ_VAL_MODE "\"" /* n-th key */
 #define JSON_KEY_CLT_ID			", \"" REQ_KEY_CLT_ID "\": \"" \
 	REQ_VAL_CLT_ID "\"" /* n-th k. */
+#define JSON_KEY_VERSION		", \"" REQ_KEY_VERSION "\": " /* n-th key */
 #define JSON_KEY_MULTIVAL		", \"" REQ_KEY_MULTIVAL "\": " /* n-th */
 #define JSON_KEY_IDX_FROZEN		", \"" REQ_KEY_IDX_FROZEN "\": " /* n-th */
 #define JSON_KEY_TIMEZONE		", \"" REQ_KEY_TIMEZONE "\": " /* n-th key */

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -136,7 +136,6 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define REQ_KEY_FETCH			"fetch_size"
 #define REQ_KEY_REQ_TOUT		"request_timeout"
 #define REQ_KEY_PAGE_TOUT		"page_timeout"
-#define REQ_KEY_TIME_ZONE		"time_zone"
 #define REQ_KEY_MODE			"mode"
 #define REQ_KEY_CLT_ID			"client_id"
 #define REQ_KEY_MULTIVAL		"field_multi_value_leniency"
@@ -163,7 +162,6 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define JSON_KEY_FETCH			", \"" REQ_KEY_FETCH "\": " /* n-th key */
 #define JSON_KEY_REQ_TOUT		", \"" REQ_KEY_REQ_TOUT "\": " /* n-th key */
 #define JSON_KEY_PAGE_TOUT		", \"" REQ_KEY_PAGE_TOUT "\": " /* n-th key */
-#define JSON_KEY_TIME_ZONE		", \"" REQ_KEY_TIME_ZONE "\": " /* n-th key */
 #define JSON_KEY_VAL_MODE		", \"" REQ_KEY_MODE "\": \"" \
 	REQ_VAL_MODE "\"" /* n-th key */
 #define JSON_KEY_CLT_ID			", \"" REQ_KEY_CLT_ID "\": \"" \

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -21,6 +21,8 @@ extern "C" {
 ConnectedDBC::ConnectedDBC()
 {
 	cstr_st types = {0};
+	static char buff[sizeof(STR(DRV_VERSION))] = {0};
+	char *ptr;
 
 	assert(getenv("TZ") == NULL);
 
@@ -46,6 +48,12 @@ ConnectedDBC::ConnectedDBC()
 	ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
 	assert(SQL_SUCCEEDED(ret));
 	assert(stmt != NULL);
+
+	version = STR(DRV_VERSION);
+	if ((ptr = strchr(version, '-'))) {
+		strncpy(buff, STR(DRV_VERSION), ptr - version);
+		version = buff;
+	}
 }
 
 ConnectedDBC::~ConnectedDBC()
@@ -104,6 +112,7 @@ void ConnectedDBC::assertRequest(const char *params, const char *tz)
 		JSON_KEY_TIMEZONE "%s%s%s"
 		JSON_KEY_VAL_MODE
 		JSON_KEY_CLT_ID
+		JSON_KEY_VERSION "\"%s\""
 		"}";
 	char expect[1024];
 	int n;
@@ -114,10 +123,10 @@ void ConnectedDBC::assertRequest(const char *params, const char *tz)
 
 	if (tz) {
 		n = snprintf(expect, sizeof(expect), answ_templ, test_name, params,
-				"\"", tz, "\"");
+				"\"", tz, "\"", version);
 	} else {
 		n = snprintf(expect, sizeof(expect), answ_templ, test_name, params,
-				"", JSON_VAL_TIMEZONE_Z, "");
+				"", JSON_VAL_TIMEZONE_Z, "", version);
 	}
 	ASSERT_LT(actual.cnt, sizeof(expect));
 	ASSERT_EQ(n, actual.cnt);

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -110,9 +110,9 @@ void ConnectedDBC::assertRequest(const char *params, const char *tz)
 		JSON_KEY_MULTIVAL ESODBC_DEF_MFIELD_LENIENT
 		JSON_KEY_IDX_FROZEN ESODBC_DEF_IDX_INC_FROZEN
 		JSON_KEY_TIMEZONE "%s%s%s"
+		JSON_KEY_VERSION "\"%s\""
 		JSON_KEY_VAL_MODE
 		JSON_KEY_CLT_ID
-		JSON_KEY_VERSION "\"%s\""
 		"}";
 	char expect[1024];
 	int n;

--- a/test/connected_dbc.h
+++ b/test/connected_dbc.h
@@ -108,6 +108,7 @@ class ConnectedDBC {
 		SQLRETURN ret;
 		SQLLEN ind_len = SQL_NULL_DATA;
 		const char *test_name;
+		char *version;
 
 
 	ConnectedDBC();


### PR DESCRIPTION
This PR relaxes the version check the driver does on connect: this
version compatibility is migrated on the server and the driver only
checks that server's version is more recent than a set minimum (that of
the release that applies version policy on the server).

(Related to https://github.com/elastic/elasticsearch/pull/53082)