### PR TITLE
Switch to CBOR as default packing mode

### DIFF
--- a/driver/queries.c
+++ b/driver/queries.c
@@ -2975,11 +2975,16 @@ static SQLRETURN statement_len_cbor(esodbc_stmt_st *stmt, size_t *enc_len,
 		bodylen += cbor_str_obj_len(tz_param.cnt); /* lax len */
 		*keys += 3; /* field_m._val., idx._inc._frozen, time_zone */
 	}
+	/* mode */
 	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_MODE) - 1);
 	bodylen += cbor_str_obj_len(sizeof(REQ_VAL_MODE) - 1);
+	/* client_id */
 	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_CLT_ID) - 1);
 	bodylen += cbor_str_obj_len(sizeof(REQ_VAL_CLT_ID) - 1);
-	*keys += 2; /* mode, client_id */
+	/* binary_format */
+	bodylen += cbor_str_obj_len(sizeof(REQ_KEY_BINARY_FMT) - 1);
+	bodylen += CBOR_OBJ_BOOL_LEN;
+	*keys += 3; /* mode, client_id, binary_format */
 	/* TODO: request_/page_timeout */
 
 	*enc_len = bodylen;
@@ -3036,6 +3041,8 @@ static SQLRETURN statement_len_json(esodbc_stmt_st *stmt, size_t *outlen)
 	}
 	bodylen += sizeof(JSON_KEY_VAL_MODE) - 1; /* "mode": */
 	bodylen += sizeof(JSON_KEY_CLT_ID) - 1; /* "client_id": */
+	bodylen += sizeof(JSON_KEY_BINARY_FMT) - 1; /* "binary_format": false */
+	bodylen += sizeof("false") - 1;
 	/* TODO: request_/page_timeout */
 	bodylen += 1; /* } */
 
@@ -3322,6 +3329,11 @@ static SQLRETURN serialize_to_cbor(esodbc_stmt_st *stmt, cstr_st *dest,
 	err = cbor_encode_text_string(&map, REQ_VAL_CLT_ID,
 			sizeof(REQ_VAL_CLT_ID) - 1);
 	FAIL_ON_CBOR_ERR(stmt, err);
+	/* binary_format: true (false means JSON) */
+	err = cbor_encode_text_string(&map, REQ_KEY_BINARY_FMT,
+			sizeof(REQ_KEY_BINARY_FMT) - 1);
+	FAIL_ON_CBOR_ERR(stmt, err);
+	err = cbor_encode_boolean(&map, TRUE);
 
 	err = cbor_encoder_close_container(&encoder, &map);
 	FAIL_ON_CBOR_ERR(stmt, err);
@@ -3430,6 +3442,10 @@ static SQLRETURN serialize_to_json(esodbc_stmt_st *stmt, cstr_st *dest)
 	pos += sizeof(JSON_KEY_VAL_MODE) - 1;
 	memcpy(body + pos, JSON_KEY_CLT_ID, sizeof(JSON_KEY_CLT_ID) - 1);
 	pos += sizeof(JSON_KEY_CLT_ID) - 1;
+	/* "binary_format": false (true means CBOR) */
+	memcpy(body + pos, JSON_KEY_BINARY_FMT, sizeof(JSON_KEY_BINARY_FMT) - 1);
+	pos += sizeof(JSON_KEY_BINARY_FMT) - 1;
+	pos += copy_bool_val(body + pos, FALSE);
 	body[pos ++] = '}';
 
 	/* check that the buffer hasn't been overrun. it can be used less than

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -142,6 +142,7 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define REQ_KEY_MULTIVAL		"field_multi_value_leniency"
 #define REQ_KEY_IDX_FROZEN		"index_include_frozen"
 #define REQ_KEY_TIMEZONE		"time_zone"
+#define REQ_KEY_BINARY_FMT		"binary_format"
 /* keys for the "params" argument */
 #define REQ_KEY_PARAM_TYPE		"type"
 #define REQ_KEY_PARAM_VAL		"value"
@@ -171,6 +172,7 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define JSON_KEY_MULTIVAL		", \"" REQ_KEY_MULTIVAL "\": " /* n-th */
 #define JSON_KEY_IDX_FROZEN		", \"" REQ_KEY_IDX_FROZEN "\": " /* n-th */
 #define JSON_KEY_TIMEZONE		", \"" REQ_KEY_TIMEZONE "\": " /* n-th key */
+#define JSON_KEY_BINARY_FMT		", \"" REQ_KEY_BINARY_FMT "\": " /* n-th key */
 
 #define JSON_VAL_TIMEZONE_Z		"\"" REQ_VAL_TIMEZONE_Z "\""
 

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
@@ -502,8 +502,8 @@ namespace EsOdbcDsnEditor
             this.comboBoxDataEncoding.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxDataEncoding.FormattingEnabled = true;
             this.comboBoxDataEncoding.Items.AddRange(new object[] {
-            "JSON",
-            "CBOR"});
+            "CBOR",
+            "JSON"});
             this.comboBoxDataEncoding.Location = new System.Drawing.Point(182, 155);
             this.comboBoxDataEncoding.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxDataEncoding.Name = "comboBoxDataEncoding";

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -157,7 +157,7 @@ namespace EsOdbcDsnEditor
 			numericUpDownFetchSize.Text = Builder.ContainsKey("MaxFetchSize") ? Builder["MaxFetchSize"].ToString().StripBraces() : "1000";
 			numericUpDownBodySize.Text = Builder.ContainsKey("MaxBodySizeMB") ? Builder["MaxBodySizeMB"].ToString().StripBraces() : "100";
 			comboBoxFloatsFormat.Text = Builder.ContainsKey("ScientificFloats") ? Builder["ScientificFloats"].ToString().StripBraces() : "default";
-			comboBoxDataEncoding.Text = Builder.ContainsKey("Packing") ? Builder["Packing"].ToString() : "JSON";
+			comboBoxDataEncoding.Text = Builder.ContainsKey("Packing") ? Builder["Packing"].ToString() : "CBOR";
 			comboBoxDataCompression.Text = Builder.ContainsKey("Compression") ? Builder["Compression"].ToString() : "auto";
 
 			string[] noes = {"no", "false", "0"};

--- a/test/connected_dbc.cc
+++ b/test/connected_dbc.cc
@@ -104,6 +104,7 @@ void ConnectedDBC::assertRequest(const char *params, const char *tz)
 		JSON_KEY_TIMEZONE "%s%s%s"
 		JSON_KEY_VAL_MODE
 		JSON_KEY_CLT_ID
+		JSON_KEY_BINARY_FMT "false"
 		"}";
 	char expect[1024];
 	int n;


### PR DESCRIPTION
This PR switches the default packing mode from JSON to CBOR.

It also always adds the "binary_encoding" boolean field to the REST requests,
which is how the server decides what to answer with (the ES/SQL plugin
overrides the Accept HTTP header).