### PR TITLE
Fixes: possible buffer overrun on interval conversion. Catalog length handling

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -3127,7 +3127,7 @@ static SQLRETURN check_catalog_name(esodbc_dbc_st *dbc, SQLWCHAR *name,
 	if (len < 0) {
 		catalog.cnt = wcslen(name);
 	} else {
-		catalog.cnt = (size_t)len;
+		catalog.cnt = ((size_t)len)/sizeof(SQLWCHAR);
 	}
 	if (! EQ_WSTR(&dbc->catalog, &catalog)) {
 		if (! dbc->catalog.cnt) {
@@ -3281,7 +3281,7 @@ SQLRETURN EsSQLSetConnectAttrW(
 		case SQL_ATTR_CURRENT_CATALOG:
 			INFOH(dbc, "setting current catalog to: `" LWPDL "`.",
 				/* string should be 0-term'd */
-				0 <= StringLength ? StringLength : SHRT_MAX,
+				0 <= StringLength ? StringLength/sizeof(SQLWCHAR) : SHRT_MAX,
 				(SQLWCHAR *)Value);
 			return check_catalog_name(dbc, (SQLWCHAR *)Value, StringLength);
 

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -4495,7 +4495,9 @@ static SQLRETURN c2sql_str2interval(esodbc_rec_st *arec, esodbc_rec_st *irec,
 			INFOH(stmt, "translation buffer too small (%zu < %lld), "
 				"allocation needed.", sizeof(wbuff)/sizeof(wbuff[0]),
 				(size_t)octet_len);
-			wptr = malloc(octet_len * sizeof(SQLWCHAR));
+			/* 0-term is most of the time not counted in input str and
+			 * ascii_c2w() writes it -> always allocate space for it */
+			wptr = malloc((octet_len + 1) * sizeof(SQLWCHAR));
 			if (! wptr) {
 				ERRNH(stmt, "OOM for %lld x SQLWCHAR", octet_len);
 				RET_HDIAGS(stmt, SQL_STATE_HY001);
@@ -4514,6 +4516,8 @@ static SQLRETURN c2sql_str2interval(esodbc_rec_st *arec, esodbc_rec_st *irec,
 			}
 			/* should only happen on too short input string */
 			RET_HDIAGS(stmt, SQL_STATE_22018);
+		} else {
+			assert(ret <= octet_len + 1); /* no overrun */
 		}
 		wstr.str = wptr;
 		wstr.cnt = (size_t)octet_len;


### PR DESCRIPTION
This PR fixes two low-probability/impact defects:
- when converting a bound parameter from string to an interval type, the destination buffer lacked space for the 0-terminator, which was nevertheless written. This was triggered by unit testing; this functionality has a very low use probability. 
- the recently added support for setting the current catalog came with a defect in the way the catalog (wide) string length was considered: character count vs. the normed byte count. That's now being corrected. This leads to the API call failure, but applications tend to ignore it, thus a low impact.