### PR TITLE
Update type selection for string parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ installer/src/Installer/driver/
 dsneditor/EsOdbcDsnEditor/Debug/
 dsneditor/EsOdbcDsnEditorLauncher/bin/
 dsneditor/EsOdbcDsnEditorLauncher/obj/
+libs/zlib/zlib.lib
 
 # User-specific files
 *.suo

--- a/build.bat
+++ b/build.bat
@@ -334,11 +334,17 @@ REM CTESTS function: run CI testing
 REM PROPER function: clean up the build and libs dir.
 :PROPER
 	echo %~nx0: cleaning libs.
-	if exist %BUILD_DIR%\zlibclean.vcxproj (
-		MSBuild %BUILD_DIR%\zlibclean.vcxproj
+	if exist %BUILDS_DIR%\x86\zlibclean.vcxproj (
+		MSBuild %BUILDS_DIR%\x86\zlibclean.vcxproj
 	)
-	if exist %BUILD_DIR%\curlclean.vcxproj (
-		MSBuild %BUILD_DIR%\curlclean.vcxproj
+	if exist %BUILDS_DIR%\x64\zlibclean.vcxproj (
+		MSBuild %BUILDS_DIR%\x64\zlibclean.vcxproj
+	)
+	if exist %BUILDS_DIR%\x86\curlclean.vcxproj (
+		MSBuild %BUILDS_DIR%\x86\curlclean.vcxproj
+	)
+	if exist %BUILDS_DIR%\x64\curlclean.vcxproj (
+		MSBuild %BUILDS_DIR%\x64\curlclean.vcxproj
 	)
 	call:CLEAN
 	REM delete VisualStudio files

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -13,6 +13,9 @@
 
 /* Tracing log buffer size. */
 #define ESODBC_LOG_BUF_SIZE			(4 * 1024)
+#ifdef WITH_EXTENDED_BUFF_LOG
+#	define ESODBC_EXT_LOG_BUF_SIZE (ESODBC_LOG_BUF_SIZE * 1024)
+#endif /* WITH_EXTENDED_BUFF_LOG */
 /* Log file prefix. The format is: prefix_datime */
 #define ESODBC_LOG_FILE_PREFIX		"esodbc"
 #define ESODBC_LOG_FILE_SUFFIX		".log"

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -2280,7 +2280,7 @@ static BOOL consistency_check(esodbc_rec_st *rec)
 				dbc = HDRH(HDRH(desc)->stmt)->dbc;
 				if (rec->concise_type == SQL_FLOAT) {
 					assert(desc->type == DESC_TYPE_IPD);
-					column_size = dbc->max_float_size;
+					column_size = dbc->max_float_type->column_size;
 				} else {
 					if (DESC_TYPE_IS_APPLICATION(desc->type)) {
 						concise_type = sqlctype_to_es(rec->concise_type);

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -173,8 +173,8 @@ typedef struct struct_dbc {
 	esodbc_estype_st *es_types; /* array with ES types */
 	SQLULEN no_types; /* number of types in array */
 	/* maximum precision/length of types using same SQL data type ID */
-	SQLINTEGER max_float_size;
-	SQLINTEGER max_varchar_size;
+	esodbc_estype_st *max_varchar_type; /* pointer to TEXT type */
+	esodbc_estype_st *max_float_type; /* pointer to DOUBLE type */
 
 	CURL *curl; /* cURL handle */
 	CURLcode curl_err;

--- a/driver/log.c
+++ b/driver/log.c
@@ -32,7 +32,6 @@
 esodbc_filelog_st *_gf_log = NULL;
 
 #ifdef WITH_EXTENDED_BUFF_LOG
-#define ESODBC_EXT_LOG_BUF_SIZE (ESODBC_LOG_BUF_SIZE * 1024)
 static char **log_buffs = NULL;
 static size_t log_buffs_cnt = 0;
 static esodbc_mutex_lt log_buffs_mux = ESODBC_MUX_SINIT;
@@ -111,6 +110,7 @@ void log_cleanup()
 		free(log_buffs);
 		log_buffs = NULL;
 		log_buffs_cnt = 0;
+		ESODBC_MUX_DEL(&log_buffs_mux);
 	}
 #	endif /* WITH_EXTENDED_BUFF_LOG */
 

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -57,6 +57,10 @@ static void driver_cleanup()
 {
 	connect_cleanup();
 	tinycbor_cleanup();
+
+#	ifdef WITH_EXTENDED_BUFF_LOG
+	cstr_hex_dump(NULL); /* util.[ch] */
+#	endif /* WITH_EXTENDED_BUFF_LOG */
 }
 
 BOOL WINAPI DllMain(

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1305,7 +1305,10 @@ SQLRETURN copy_one_row_json(esodbc_stmt_st *stmt, SQLULEN pos)
 
 	ard = stmt->ard;
 	ird = stmt->ird;
-	rowno = stmt->tv_rows + /* current not yet counted */1;
+	rowno = stmt->tv_rows
+		+ STMT_GD_CALLING(stmt)
+		? /* SQLFetch() executed already, row counted */0
+		: /* SQLFetch() in progress, current row not yet counted */1;
 
 	with_info = FALSE;
 	/* iterate over the bound cols of one (table) row */
@@ -1496,7 +1499,10 @@ static SQLRETURN copy_one_row_cbor(esodbc_stmt_st *stmt, SQLULEN pos)
 
 	ard = stmt->ard;
 	ird = stmt->ird;
-	rowno = stmt->tv_rows + /* current row not yet counted */1;
+	rowno = stmt->tv_rows
+		+ STMT_GD_CALLING(stmt)
+		? /* SQLFetch() executed already, row counted */0
+		: /* SQLFetch() in progress, current row not yet counted */1;
 
 	with_info = FALSE;
 	/* iterate over the bound cols and contents of one (table) row */
@@ -2425,30 +2431,33 @@ SQLRETURN EsSQLPrepareW
 
 
 /* Find the ES/SQL type given in es_type; for ID matching multiple types
- * (scaled/half_float and keyword/text) use the best matching col_size, which
- * is the smallest, that's still matching (<=) the given one. This assumes the
- * types are ordered by it (as per the spec). */
+ * (scaled/half_float), but not  keyword/text, use the best matching col_size,
+ * which is the smallest, that's still matching (<=) the given one. This
+ * assumes the types are ordered by it (as per the spec). */
 esodbc_estype_st *lookup_es_type(esodbc_dbc_st *dbc,
 	SQLSMALLINT es_type, SQLULEN col_size)
 {
 	SQLULEN i;
+	SQLINTEGER sz;
 
+	/* for strings, choose text straight away: some type (IP, GEO) must coform
+	 * to a format and no content inspection is done in the driver */
+	if (es_type == SQL_VARCHAR) {
+		return dbc->max_varchar_type;
+	}
 	for (i = 0; i < dbc->no_types; i ++) {
 		if (dbc->es_types[i].data_type == es_type) {
 			if (col_size <= 0) {
 				return &dbc->es_types[i];
 			} else {
+				sz = dbc->es_types[i].column_size;
 				assert(col_size < LONG_MAX);
-				if ((SQLINTEGER)col_size <= dbc->es_types[i].column_size) {
-					return &dbc->es_types[i];
-				}
-				if (es_type == SQL_VARCHAR &&
-					dbc->es_types[i].column_size == dbc->max_varchar_size) {
+				if ((SQLINTEGER)col_size <= sz) {
 					return &dbc->es_types[i];
 				}
 				if (es_type == SQL_FLOAT &&
-					dbc->es_types[i].column_size == dbc->max_float_size) {
-					return &dbc->es_types[i];
+						sz == dbc->max_float_type->column_size) {
+					return dbc->max_float_type;
 				}
 			}
 		}
@@ -2460,33 +2469,28 @@ esodbc_estype_st *lookup_es_type(esodbc_dbc_st *dbc,
 
 /* find the matching ES/SQL type for app's SQL type, which can be an exact
  * match against ES/SQL types, but also some other valid SQL type. */
-static esodbc_estype_st *match_es_type(esodbc_rec_st *arec,
-	esodbc_rec_st *irec)
+static esodbc_estype_st *match_es_type(esodbc_rec_st *irec)
 {
-	SQLULEN i, length;
-	esodbc_dbc_st *dbc = arec->desc->hdr.stmt->hdr.dbc;
+	SQLULEN i;
+	SQLINTEGER col_sz;
+	esodbc_dbc_st *dbc = irec->desc->hdr.stmt->hdr.dbc;
 
 	for (i = 0; i < dbc->no_types; i ++) {
 		if (dbc->es_types[i].data_type == irec->concise_type) {
 			switch (irec->concise_type) {
-				/* For SQL types mappign to more than one ES/SQL type, choose
+				/* For SQL types mapping to more than one ES/SQL type, choose
 				 * the ES/SQL type with smallest "size" that covers user given
 				 * precision OR that has maximum precision (in case user's is
 				 * larger than max ES/SQL offers. */
 				case SQL_FLOAT: /* HALF_FLOAT, SCALED_FLOAT */
-					if (irec->precision <= dbc->es_types[i].column_size ||
-						dbc->es_types[i].column_size == dbc->max_float_size) {
+					col_sz = dbc->es_types[i].column_size;
+					if (irec->precision <= col_sz ||
+						col_sz == dbc->max_float_type->column_size) {
 						return &dbc->es_types[i];
 					}
 					break;
-				case SQL_VARCHAR: /* KEYWORD, TEXT */
-					length = irec->length ? irec->length : arec->octet_length;
-					assert(length < LONG_MAX);
-					if ((SQLINTEGER)length <= dbc->es_types[i].column_size ||
-						dbc->es_types[i].column_size==dbc->max_varchar_size) {
-						return &dbc->es_types[i];
-					}
-					break;
+				case SQL_VARCHAR: /* IP, CONSTANT_KEYWORD, KEYWORD, TEXT */
+					return lookup_es_type(dbc, SQL_VARCHAR, irec->precision);
 				default:
 					/* unequivocal match */
 					return &dbc->es_types[i];
@@ -2494,8 +2498,7 @@ static esodbc_estype_st *match_es_type(esodbc_rec_st *arec,
 		}
 	}
 
-	/* app specified an SQL type with no direct mapping to an ES/SQL type
-	 * TODO: IP, GEO? */
+	/* app specified an SQL type with no direct mapping to an ES/SQL type */
 	switch (irec->meta_type) {
 		case METATYPE_EXACT_NUMERIC:
 			assert(irec->concise_type == SQL_DECIMAL ||
@@ -2503,8 +2506,7 @@ static esodbc_estype_st *match_es_type(esodbc_rec_st *arec,
 			return lookup_es_type(dbc, SQL_FLOAT, irec->precision);
 
 		case METATYPE_STRING:
-			length = irec->length ? irec->length : arec->octet_length;
-			return lookup_es_type(dbc, SQL_VARCHAR, length);
+			return lookup_es_type(dbc, SQL_VARCHAR, irec->precision);
 		case METATYPE_BIN:
 			return lookup_es_type(dbc, SQL_BINARY, /*no prec*/0);
 		case METATYPE_DATE_TIME:
@@ -2698,7 +2700,7 @@ SQLRETURN EsSQLBindParameter(
 	}
 
 	arec = get_record(stmt->apd, ParameterNumber, /*grow?*/FALSE);
-	irec->es_type = match_es_type(arec, irec);
+	irec->es_type = match_es_type(irec);
 	if (! irec->es_type) {
 		/* validation shoudl have been done earlier on meta type setting
 		 * (SQL_DESC_CONCISE_TYPE) */

--- a/test/integration/install.py
+++ b/test/integration/install.py
@@ -16,8 +16,8 @@ import tempfile
 from elasticsearch import Elasticsearch
 
 DRIVER_BASE_NAME = "Elasticsearch ODBC Driver"
-# Uninstallation can take quite a long time (over 10s)
-INSTALLATION_TIMEOUT = 60
+# Uninstallation can take quite a long time on VMs
+INSTALLATION_TIMEOUT = 120
 
 class Installer(object):
 	_driver_path = None

--- a/test/test_conversion_c2sql_varchar.cc
+++ b/test/test_conversion_c2sql_varchar.cc
@@ -25,7 +25,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_empty)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", \"value\": \"\"}]");
+	assertRequest("[{\"type\": \"TEXT\", \"value\": \"\"}]");
 }
 
 /* note: test name used in test */
@@ -39,7 +39,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_empty)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", \"value\": \"\"}]");
+	assertRequest("[{\"type\": \"TEXT\", \"value\": \"\"}]");
 }
 
 /* note: test name used in test */
@@ -53,7 +53,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", \"value\": \"0123abcABC\"}]");
+	assertRequest("[{\"type\": \"TEXT\", \"value\": \"0123abcABC\"}]");
 }
 
 /* note: test name used in test */
@@ -67,7 +67,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", \"value\": \"0123abcABC\"}]");
+	assertRequest("[{\"type\": \"TEXT\", \"value\": \"0123abcABC\"}]");
 }
 
 /* note: test name used in test */
@@ -81,7 +81,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_ansi_jsonescape)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]");
 }
 
@@ -96,7 +96,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape_oct_len_ptr)
 			&octet_len);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]");
 }
 
@@ -111,7 +111,7 @@ TEST_F(ConvertC2SQL_Varchar, CStr2Varchar_jsonescape)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"START_{xxx}=\\\"yyy\\\"\\r__END\"}]");
 }
 
@@ -126,7 +126,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_jsonescape)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"START_\\\"A\u00C4o\u00F6U\u00FC\\\"__END\"}]");
 }
 
@@ -141,7 +141,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape_oct_len_ptr)
 			&octet_len);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}]");
 }
 
@@ -156,7 +156,7 @@ TEST_F(ConvertC2SQL_Varchar, WStr2Varchar_u8_fullescape)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\"}]");
 }
 
@@ -171,7 +171,7 @@ TEST_F(ConvertC2SQL_Varchar, Short2Varchar)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", \"value\": \"-12345\"}]");
+	assertRequest("[{\"type\": \"TEXT\", \"value\": \"-12345\"}]");
 }
 
 /* note: test name used in test */
@@ -185,7 +185,7 @@ TEST_F(ConvertC2SQL_Varchar, Bigint2Varchar)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"9223372036854775807\"}]");
 }
 
@@ -218,7 +218,7 @@ TEST_F(ConvertC2SQL_Varchar, Double2Varchar)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"1.20000000\"}]");
 }
 
@@ -232,7 +232,7 @@ TEST_F(ConvertC2SQL_Varchar, Double2Varchar_strip_trailing_dot)
 			/*IndLen*/NULL);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	assertRequest("[{\"type\": \"KEYWORD\", "
+	assertRequest("[{\"type\": \"TEXT\", "
 		"\"value\": \"-9999\"}]");
 }
 


### PR DESCRIPTION
This PR changes the way a parameter's SQL type is resolved to an ES
type. So far, the size of the parameter was taken into account, to
select the ES type with the lowest "precision" that would accomodate it.

This worked well so far because IP type was having a precision of 0 (=ignored).
This precision for IP type had been updated in Elasticsearch (to maximum
IP length), which would lead to the driver tagging small length strings
as IP types.

With current change, all string type parameterss are considered as TEXT
types, leaving Elasticsearch/SQL to apply a better, context-informed
conversion.

The PR also extends the size of binary-to-hexa logging and does a better
cleaning with "proper" build script parameter.