### PR TITLE
Fix: SQLGetData: only update offset if C-string data copied out

### DIFF
--- a/driver/convert.c
+++ b/driver/convert.c
@@ -1487,13 +1487,13 @@ static SQLRETURN wstr_to_cstr(esodbc_rec_st *arec, esodbc_rec_st *irec,
 					ERRNH(stmt, "failed to convert wchar_t* to char* for "
 						"string `" LWPDL "`.", c, xstr.w.str);
 					RET_HDIAGS(stmt, SQL_STATE_22018);
-				} // else: buffer too small for full string: trimm further
+				} // else: buffer too small for full string: trim further
 			}
 
 			assert(0 < out_bytes);
 			if (charp[out_bytes - 1] != '\0') {
 				/* ran out of buffer => not 0-term'd and truncated already */
-				charp[out_bytes - 1] = 0;
+				charp[out_bytes - 1] = '\0';
 				state = SQL_STATE_01004; /* indicate truncation */
 				c --; /* last char was overwritten with 0 -> dec xfed count */
 			}

--- a/test/test_sqlgetdata.cc
+++ b/test/test_sqlgetdata.cc
@@ -133,6 +133,11 @@ TEST_F(GetData, String2Char_zero_copy) {
 	ret = SQLGetData(stmt, /*col*/1, SQL_C_CHAR, buff, 0, &ind_len);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 	EXPECT_EQ(ind_len, sizeof(SQL_VAL) - /*\0*/1);
+
+	/* check if data is still available */
+	ret = SQLGetData(stmt, /*col*/1, SQL_C_CHAR, buff, sizeof(buff), NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ASSERT_STREQ(SQL_VAL, (char *)buff);
 }
 
 
@@ -257,6 +262,12 @@ TEST_F(GetData, String2WChar_zero_copy) {
 	ret = SQLGetData(stmt, /*col*/1, SQL_C_WCHAR, buff, 0, &ind_len);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 	EXPECT_EQ(ind_len/sizeof(*buff), sizeof(SQL_VAL) - /*\0*/1);
+
+	/* check if data is still available */
+	ret = SQLGetData(stmt, /*col*/1, SQL_C_WCHAR, buff,
+			sizeof(buff)/sizeof(buff[0]), NULL);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	EXPECT_STREQ(MK_WPTR(SQL_VAL), (wchar_t *)buff);
 }
 
 TEST_F(GetData, String2SLong) {


### PR DESCRIPTION
This PR fixes a defect manifesting when getting C-strings with
SQLGetData, in two steps: a first invocation with a 0-space buffer, to
fetch the length of data available, then a subsequent one, with
appropriate buffer size, to actually fetch the data.

The second call would so far fail with "no data available anymore",
since the offset of so-far-read-data was incorrectly updated, also in
the case when no data was actually copied. This commit fixes it, only
updating the offset if there's space in output buffer to copy.

Fetching wide-strings works correctly.

Fixes #220.