### PR TITLE
Add an early execution mode for prepared statements

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1402,6 +1402,9 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 	/* "apply TZ" param for time conversions */
 	dbc->apply_tz = wstr2bool(&attrs->apply_tz);
 	INFOH(dbc, "apply TZ: %s.", dbc->apply_tz ? "true" : "false");
+	/* early execution */
+	dbc->early_exec = wstr2bool(&attrs->early_exec);
+	INFOH(dbc, "early execution: %s.", dbc->early_exec ? "true" : "false");
 
 	/* how to print the floats? */
 	assert(1 <= attrs->sci_floats.cnt); /* default should apply */

--- a/driver/defs.h
+++ b/driver/defs.h
@@ -173,6 +173,8 @@
 #define ESODBC_DEF_TRACE_LEVEL		"WARN"
 /* default TZ handling */
 #define ESODBC_DEF_APPLY_TZ			"no"
+/* default early execution flag */
+#define ESODBC_DEF_EARLY_EXEC		"yes"
 /* default of scientific floats printing */
 #define ESODBC_DEF_SCI_FLOATS		ESODBC_DSN_FLTS_DEF
 #define ESODBC_PWD_VAL_SUBST		"<redacted>"

--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -76,6 +76,7 @@ int assign_dsn_attr(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE), &attrs->max_fetch_size},
 		{&MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB), &attrs->max_body_size},
 		{&MK_WSTR(ESODBC_DSN_APPLY_TZ), &attrs->apply_tz},
+		{&MK_WSTR(ESODBC_DSN_EARLY_EXEC), &attrs->early_exec},
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
@@ -411,6 +412,7 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE), &attrs->max_fetch_size},
 		{&MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB), &attrs->max_body_size},
 		{&MK_WSTR(ESODBC_DSN_APPLY_TZ), &attrs->apply_tz},
+		{&MK_WSTR(ESODBC_DSN_EARLY_EXEC), &attrs->early_exec},
 		{&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &attrs->sci_floats},
 		{&MK_WSTR(ESODBC_DSN_VERSION_CHECKING), &attrs->version_checking},
 		{&MK_WSTR(ESODBC_DSN_MFIELD_LENIENT), &attrs->mfield_lenient},
@@ -676,6 +678,10 @@ BOOL write_system_dsn(esodbc_dsn_attrs_st *new_attrs,
 			old_attrs ? &old_attrs->apply_tz : NULL
 		},
 		{
+			&MK_WSTR(ESODBC_DSN_EARLY_EXEC), &new_attrs->early_exec,
+			old_attrs ? &old_attrs->early_exec : NULL
+		},
+		{
 			&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &new_attrs->sci_floats,
 			old_attrs ? &old_attrs->sci_floats : NULL
 		},
@@ -786,6 +792,7 @@ long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 		{&attrs->max_fetch_size, &MK_WSTR(ESODBC_DSN_MAX_FETCH_SIZE)},
 		{&attrs->max_body_size, &MK_WSTR(ESODBC_DSN_MAX_BODY_SIZE_MB)},
 		{&attrs->apply_tz, &MK_WSTR(ESODBC_DSN_APPLY_TZ)},
+		{&attrs->early_exec, &MK_WSTR(ESODBC_DSN_EARLY_EXEC)},
 		{&attrs->sci_floats, &MK_WSTR(ESODBC_DSN_SCI_FLOATS)},
 		{&attrs->version_checking, &MK_WSTR(ESODBC_DSN_VERSION_CHECKING)},
 		{&attrs->mfield_lenient, &MK_WSTR(ESODBC_DSN_MFIELD_LENIENT)},
@@ -883,6 +890,9 @@ void assign_dsn_defaults(esodbc_dsn_attrs_st *attrs)
 
 	res |= assign_dsn_attr(attrs,
 			&MK_WSTR(ESODBC_DSN_APPLY_TZ), &MK_WSTR(ESODBC_DEF_APPLY_TZ),
+			/*overwrite?*/FALSE);
+	res |= assign_dsn_attr(attrs,
+			&MK_WSTR(ESODBC_DSN_EARLY_EXEC), &MK_WSTR(ESODBC_DEF_EARLY_EXEC),
 			/*overwrite?*/FALSE);
 	res |= assign_dsn_attr(attrs,
 			&MK_WSTR(ESODBC_DSN_SCI_FLOATS), &MK_WSTR(ESODBC_DEF_SCI_FLOATS),

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -35,6 +35,7 @@
 #define ESODBC_DSN_MAX_FETCH_SIZE	"MaxFetchSize"
 #define ESODBC_DSN_MAX_BODY_SIZE_MB	"MaxBodySizeMB"
 #define ESODBC_DSN_APPLY_TZ			"ApplyTZ"
+#define ESODBC_DSN_EARLY_EXEC		"EarlyExecution"
 #define ESODBC_DSN_SCI_FLOATS		"ScientificFloats"
 #define ESODBC_DSN_VERSION_CHECKING	"VersionChecking"
 #define ESODBC_DSN_MFIELD_LENIENT	"MultiFieldLenient"
@@ -78,6 +79,7 @@ typedef struct {
 	wstr_st max_fetch_size;
 	wstr_st max_body_size;
 	wstr_st apply_tz;
+	wstr_st early_exec;
 	wstr_st sci_floats;
 	wstr_st version_checking;
 	wstr_st mfield_lenient;
@@ -86,7 +88,7 @@ typedef struct {
 	wstr_st trace_enabled;
 	wstr_st trace_file;
 	wstr_st trace_level;
-#define ESODBC_DSN_ATTRS_COUNT	28
+#define ESODBC_DSN_ATTRS_COUNT	29
 	SQLWCHAR buff[ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN];
 	/* DSN reading/writing functions are passed a SQLSMALLINT lenght param */
 #if SHRT_MAX < ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN

--- a/driver/handles.c
+++ b/driver/handles.c
@@ -170,6 +170,7 @@ static void init_stmt(esodbc_stmt_st *stmt, SQLHANDLE InputHandle)
 	 * set at connection level. */
 	stmt->metadata_id = DBCH(InputHandle)->metadata_id;
 	stmt->sql2c_conversion = CONVERSION_UNCHECKED;
+	stmt->early_executed = FALSE;
 }
 
 void dump_record(esodbc_rec_st *rec)

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -161,6 +161,7 @@ typedef struct struct_dbc {
 		ESODBC_CMPSS_AUTO,
 	} compression;
 	BOOL apply_tz; /* should the times be converted from UTC to local TZ? */
+	BOOL early_exec; /* should prepared, non-param queries be exec'd early? */
 	enum {
 		ESODBC_FLTS_DEFAULT = 0,
 		ESODBC_FLTS_SCIENTIFIC,
@@ -391,6 +392,8 @@ typedef struct struct_stmt {
 		CONVERSION_SUPPORTED,
 		CONVERSION_SKIPPED, /* used with driver's meta queries */
 	} sql2c_conversion;
+	/* early execution */
+	BOOL early_executed;
 
 	/* SQLGetData state members */
 	SQLINTEGER gd_col; /* current column to get from, if positive */


### PR DESCRIPTION
This PR adds an early execution mode for prepared queries.

Applications generally prepare a statement, optionally reading result
set attributes - like columns count and their characteristics (types and
names) - before executing. A subset of these apps (generally the ones
following older API usage patterns) will fail the entire operation if
these column characteristics aren't available before execution.

Elasticsearch/SQL doesn't support the concept of prepared statements.
What the driver will now do if this mode is enabled (=the new default)
is to execute the query right away, in case this lacks any parameters.
In case the parameter marks are present, the early execution is disabled
for the statement (and potentially the query will fail). However, most
patterns of Elasticsearch/ODBC usage don't involve parameters and/or
repeated executions.

This change will allow more applications interop with
Elasticsearch/SQL.