### PR TITLE
Fix debug printing of SQL(U)LEN variables

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -2412,7 +2412,7 @@ static void set_display_size(esodbc_estype_st *es_type)
 	}
 
 	DBG("data type: %hd, display size: %lld", es_type->data_type,
-		es_type->display_size);
+		(int64_t)es_type->display_size);
 }
 
 static BOOL bind_types_cols(esodbc_stmt_st *stmt, estype_row_st *type_row)
@@ -3264,14 +3264,14 @@ SQLRETURN EsSQLSetConnectAttrW(
 
 		case SQL_ATTR_ASYNC_ENABLE:
 			ERRH(dbc, "no support for async API (setting param: %llu)",
-				(SQLULEN)(uintptr_t)Value);
+				(uint64_t)Value);
 			if ((SQLULEN)(uintptr_t)Value == SQL_ASYNC_ENABLE_ON) {
 				RET_HDIAGS(dbc, SQL_STATE_HYC00);
 			}
 			break;
 		case SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE:
 			ERRH(dbc, "no support for async API (setting param: %llu)",
-				(SQLULEN)(uintptr_t)Value);
+				(uint64_t)Value);
 			if ((SQLULEN)(uintptr_t)Value == SQL_ASYNC_DBC_ENABLE_ON) {
 				RET_HDIAGS(dbc, SQL_STATE_HY114);
 			}
@@ -3370,8 +3370,8 @@ SQLRETURN EsSQLSetConnectAttrW(
 
 		case SQL_ATTR_MAX_ROWS: /* stmt attr -- 2.x app */
 			WARNH(dbc, "applying a statement as connection attribute (2.x?)");
-			DBGH(dbc, "setting max rows: %llu.", (SQLULEN)Value);
-			if ((SQLULEN)Value != 0) {
+			DBGH(dbc, "setting max rows: %llu.", (uint64_t)Value);
+			if (Value) {
 				WARNH(dbc, "requested max_rows substituted with 0.");
 				RET_HDIAGS(dbc, SQL_STATE_01S02);
 			}
@@ -3429,7 +3429,7 @@ SQLRETURN EsSQLGetConnectAttrW(
 			*(SQLULEN *)ValuePtr = dbc->metadata_id;
 			break;
 		case SQL_ATTR_ASYNC_ENABLE:
-			DBGH(dbc, "getting async mode: %llu", SQL_ASYNC_ENABLE_OFF);
+			DBGH(dbc, "getting async mode: %lu", SQL_ASYNC_ENABLE_OFF);
 			*(SQLULEN *)ValuePtr = SQL_ASYNC_ENABLE_OFF;
 			break;
 

--- a/driver/convert.c
+++ b/driver/convert.c
@@ -447,7 +447,7 @@ inline void *deferred_address(SQLSMALLINT field_id, size_t pos,
 #undef ROW_OFFSETS
 
 	DBGH(desc->hdr.stmt, "rec@0x%p, field_id:%hd, pos: %zu : base@0x%p, "
-		"offset=%lld, elem_size=%zu", rec, field_id, pos, base, offt,
+		"offset=%lld, elem_size=%zu", rec, field_id, pos, base, (int64_t)offt,
 		elem_size);
 
 	return base ? (char *)base + offt + pos * elem_size : NULL;
@@ -600,7 +600,7 @@ static inline void gd_offset_apply(esodbc_stmt_st *stmt, xstr_st *xstr)
 		xstr->c.cnt -= stmt->gd_offt;
 	}
 
-	DBGH(stmt, "applied an offset of %lld.", stmt->gd_offt);
+	DBGH(stmt, "applied an offset of %lld.", (int64_t)stmt->gd_offt);
 }
 
 /*
@@ -622,7 +622,7 @@ static inline void gd_offset_update(esodbc_stmt_st *stmt, size_t cnt,
 	}
 
 	DBGH(stmt, "offset updated with %zu to new value of %lld.", xfed,
-		stmt->gd_offt);
+		(int64_t)stmt->gd_offt);
 }
 
 
@@ -990,7 +990,7 @@ SQLRETURN sql2c_longlong(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		*(_sqlctype *)data_ptr = (_sqlctype)_ll; \
 		write_out_octets(octet_len_ptr, sizeof(_sqlctype), irec); \
 		DBGH(stmt, "converted long long %lld to " STR(_sqlctype) " 0x%llx.", \
-			_ll, (intptr_t)*(_sqlctype *)data_ptr); \
+			_ll, (uint64_t)*(_sqlctype *)data_ptr); \
 	} while (0)
 
 	switch ((ctype = get_rec_c_type(arec, irec))) {
@@ -3811,7 +3811,8 @@ SQLRETURN c2sql_boolean(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	}
 	/*INDENT-ON*/
 
-	DBGH(stmt, "parameter (pos#%lld) converted to boolean: %d.", pos, val);
+	DBGH(stmt, "parameter (pos#%llu) converted to boolean: %d.",
+			(uint64_t)pos, val);
 
 	if (val) {
 		memcpy(dest, JSON_VAL_TRUE, sizeof(JSON_VAL_TRUE) - /*\0*/1);
@@ -4063,7 +4064,7 @@ static SQLRETURN binary_to_number(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		if (osize != sizeof(_sqlc_type)) { \
 			ERRH(stmt, "binary data length (%zu) misaligned with target" \
 				" data type (%hd) size (%lld)", sizeof(_sqlc_type), \
-				irec->es_type->data_type, osize); \
+				irec->es_type->data_type, (int64_t)osize); \
 			RET_HDIAGS(stmt, SQL_STATE_HY090); \
 		} \
 	} while (0)
@@ -4321,10 +4322,10 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 	esodbc_stmt_st *stmt = HDRH(irec->desc)->stmt;
 
 	colsize = get_param_size(irec);
-	DBGH(stmt, "requested column size: %llu.", colsize);
+	DBGH(stmt, "requested column size: %llu.", (uint64_t)colsize);
 
 	decdigits = get_param_decdigits(irec);
-	DBGH(stmt, "requested decimal digits: %llu.", decdigits);
+	DBGH(stmt, "requested decimal digits: %hd.", decdigits);
 	if (ESODBC_MAX_SEC_PRECISION < decdigits) {
 		WARNH(stmt, "requested decimal digits adjusted from %hd to %d (max).",
 			decdigits, ESODBC_MAX_SEC_PRECISION);
@@ -4337,7 +4338,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 				if (colsize < TIME_TEMPLATE_LEN(0) ||
 					colsize == TIME_TEMPLATE_LEN(1) - 1 /* `:ss.`*/) {
 					ERRH(stmt, "invalid column size value: %llu; allowed: "
-						"8 or 9 + fractions count.", colsize);
+						"8 or 9 + fractions count.", (uint64_t)colsize);
 					RET_HDIAGS(stmt, SQL_STATE_HY104);
 				}
 				colsize += DATE_TEMPLATE_LEN + /* ` `/`T` */1;
@@ -4349,7 +4350,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 			if (colsize) {
 				if (colsize != DATE_TEMPLATE_LEN) {
 					ERRH(stmt, "invalid column size value: %llu; allowed: "
-						"%zu.", colsize, DATE_TEMPLATE_LEN);
+						"%zu.", (uint64_t)colsize, DATE_TEMPLATE_LEN);
 					RET_HDIAGS(stmt, SQL_STATE_HY104);
 				}
 				colsize += /* ` `/`T` */1 + TIME_TEMPLATE_LEN(0);
@@ -4364,7 +4365,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 			if (colsize && (colsize < TIMESTAMP_NOSEC_TEMPLATE_LEN ||
 					colsize == 17 || colsize == 18)) {
 				ERRH(stmt, "invalid column size value: %llu; allowed: "
-					"16, 19 or 20 + fractions count.", colsize);
+					"16, 19 or 20 + fractions count.", (uint64_t)colsize);
 				RET_HDIAGS(stmt, SQL_STATE_HY104);
 			}
 			break;
@@ -4373,7 +4374,7 @@ static SQLRETURN size_decdigits_for_iso8601(esodbc_rec_st *irec,
 	}
 
 	DBGH(stmt, "applying: column size: %llu, decimal digits: %hd.",
-		colsize, decdigits);
+		(uint64_t)colsize, decdigits);
 	*_colsize = colsize;
 	*_decdigits = decdigits;
 	return SQL_SUCCESS;
@@ -4513,21 +4514,22 @@ static SQLRETURN c2sql_str2interval(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	} else {
 		octet_len = *octet_len_ptr;
 		if (octet_len <= 0) {
-			ERRH(stmt, "invalid interval buffer length: %llu.", octet_len);
+			ERRH(stmt, "invalid interval buffer length: %lld.",
+					(int64_t)octet_len);
 			RET_HDIAGS(stmt, SQL_STATE_HY090);
 		}
 	}
 
 	if (ctype == SQL_C_CHAR) {
 		if (sizeof(wbuff)/sizeof(wbuff[0]) < (size_t)octet_len) {
-			INFOH(stmt, "translation buffer too small (%zu < %lld), "
+			INFOH(stmt, "translation buffer too small (%zu < %zu), "
 				"allocation needed.", sizeof(wbuff)/sizeof(wbuff[0]),
 				(size_t)octet_len);
 			/* 0-term is most of the time not counted in input str and
 			 * ascii_c2w() writes it -> always allocate space for it */
 			wptr = malloc((octet_len + 1) * sizeof(SQLWCHAR));
 			if (! wptr) {
-				ERRNH(stmt, "OOM for %lld x SQLWCHAR", octet_len);
+				ERRNH(stmt, "OOM for %lld x SQLWCHAR", (int64_t)octet_len);
 				RET_HDIAGS(stmt, SQL_STATE_HY001);
 			}
 		} else {
@@ -4536,7 +4538,7 @@ static SQLRETURN c2sql_str2interval(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		ret = ascii_c2w((SQLCHAR *)data_ptr, wptr, octet_len);
 		if (ret <= 0) {
 			ERRH(stmt, "SQLCHAR-to-SQLWCHAR conversion failed for "
-				"[%lld] `" LCPDL "`.", octet_len, octet_len,
+				"[%lld] `" LCPDL "`.", (int64_t)octet_len, octet_len,
 				(char *)data_ptr);
 			if (wptr != wbuff) {
 				free(wptr);
@@ -4779,7 +4781,7 @@ static SQLRETURN c2sql_cstr2qstr(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		*dest = '"';
 	} else if ((SQLLEN)get_param_size(irec) < cnt) {
 		ERRH(stmt, "string's length (%lld) longer than parameter size (%llu).",
-			cnt, get_param_size(irec));
+			(int64_t)cnt, (uint64_t)get_param_size(irec));
 		RET_HDIAGS(stmt, SQL_STATE_22001);
 	}
 
@@ -4814,13 +4816,13 @@ static SQLRETURN c2sql_wstr2qstr(esodbc_rec_st *arec, esodbc_rec_st *irec,
 	} else {
 		if ((SQLLEN)get_param_size(irec) < cnt) {
 			ERRH(stmt, "string's length (%lld) longer than parameter "
-				"size (%llu).", cnt, get_param_size(irec));
+				"size (%llu).", (int64_t)cnt, (uint64_t)get_param_size(irec));
 			RET_HDIAGS(stmt, SQL_STATE_22001);
 		}
 	}
 
 	DBGH(stmt, "converting w-string [%lld] `" LWPDL "`; target@0x%p.",
-		cnt, cnt, (wchar_t *)data_ptr, dest);
+		(int64_t)cnt, cnt, (wchar_t *)data_ptr, dest);
 	if (cnt) { /* U16WC_TO_MBU8 will fail with empty string, but set no err */
 		WAPI_CLR_ERRNO();
 		octets = U16WC_TO_MBU8((wchar_t *)data_ptr, cnt, dest + !!dest,
@@ -4868,7 +4870,7 @@ static SQLRETURN c2sql_number2qstr(esodbc_rec_st *arec, esodbc_rec_st *irec,
 		/* compare lengths only once number has actually been converted */
 		if (get_param_size(irec) < *len) {
 			ERRH(stmt, "converted number length (%zu) larger than parameter "
-				"size (%llu)", *len, get_param_size(irec));
+				"size (%llu)", *len, (uint64_t)get_param_size(irec));
 			RET_HDIAGS(stmt, SQL_STATE_22003);
 		}
 		dest[*len + /*1st `"`*/1] = '"';

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -1243,7 +1243,7 @@ SQLRETURN EsSQLBindCol(
 
 	DBGH(stmt, "succesfully bound column #%hu of type %hd, "
 		"buffer@0x%p of length: %lld, LenInd@0x%p", ColumnNumber, TargetType,
-		TargetValue, BufferLength, StrLen_or_Ind);
+		TargetValue, (int64_t)BufferLength, StrLen_or_Ind);
 
 	return SQL_SUCCESS;
 
@@ -1905,7 +1905,7 @@ SQLRETURN EsSQLFetch(SQLHSTMT StatementHandle)
 
 	/* return number of processed rows (even if 0) */
 	if (ird->rows_processed_ptr) {
-		DBGH(stmt, "setting number of processed rows to: %llu.", i);
+		DBGH(stmt, "setting number of processed rows to: %llu.", (uint64_t)i);
 		*ird->rows_processed_ptr = i;
 	}
 
@@ -1917,7 +1917,7 @@ SQLRETURN EsSQLFetch(SQLHSTMT StatementHandle)
 	}
 
 	if (errors && i <= errors) {
-		ERRH(stmt, "processing failed for all rows [%llu].", errors);
+		ERRH(stmt, "processing failed for all rows [%llu].", (uint64_t)errors);
 		return SQL_ERROR;
 	}
 
@@ -1957,7 +1957,7 @@ static SQLRETURN gd_checks(esodbc_stmt_st *stmt, SQLUSMALLINT colno)
 	/* is there a block cursor bound? */
 	if (1 < stmt->ard->array_size) {
 		ERRH(stmt, "can't use function with block cursor "
-			"(array_size=%llu).", stmt->ard->array_size);
+			"(array_size=%llu).", (uint64_t)stmt->ard->array_size);
 		RET_HDIAGS(stmt, SQL_STATE_HYC00);
 	}
 #	ifndef NDEBUG
@@ -2045,7 +2045,7 @@ SQLRETURN EsSQLGetData(
 
 	if (stmt->gd_col == ColumnNumber && stmt->gd_ctype == TargetType) {
 		DBGH(stmt, "resuming get on column #%hu (pos @ %lld).",
-			stmt->gd_col, stmt->gd_offt);
+			stmt->gd_col, (int64_t)stmt->gd_offt);
 		if (stmt->gd_offt < 0) {
 			WARNH(stmt, "data for current column exhausted.");
 			return SQL_NO_DATA;
@@ -2054,7 +2054,8 @@ SQLRETURN EsSQLGetData(
 		if (0 <= stmt->gd_col) {
 			DBGH(stmt, "previous source column #%hu (pos @ %lld), SQL C %hd "
 				"abandoned for new #%hu, SQL C %hd.", stmt->gd_col,
-				stmt->gd_offt, stmt->gd_ctype, ColumnNumber, TargetType);
+				(int64_t)stmt->gd_offt, stmt->gd_ctype, ColumnNumber,
+				TargetType);
 			/* reset fields now, should the call eventually fail */
 			STMT_GD_RESET(stmt);
 		} else {
@@ -2099,7 +2100,7 @@ SQLRETURN EsSQLGetData(
 	}
 
 	DBGH(stmt, "succesfully copied data from column #%hu (pos @ %lld), "
-		"SQL C %hd.", ColumnNumber, stmt->gd_offt, TargetType);
+		"SQL C %hd.", ColumnNumber, (int64_t)stmt->gd_offt, TargetType);
 end:
 	/* XXX: if get_record(gd_ard, ColumnNumber)->meta_type != string/bin,
 	 * should stmt->gd_offt bet set to -1 ?? */
@@ -2603,7 +2604,7 @@ SQLRETURN EsSQLBindParameter(
 		if (*StrLen_or_IndPtr == SQL_DATA_AT_EXEC ||
 			*StrLen_or_IndPtr < SQL_NTSL) {
 			ERRH(stmt, "data-at-exec not supported (LenInd=%lld).",
-				*StrLen_or_IndPtr);
+				(int64_t)*StrLen_or_IndPtr);
 			RET_HDIAG(stmt, SQL_STATE_HYC00, "data-at-exec not supported", 0);
 		}
 	} else {
@@ -2739,8 +2740,9 @@ SQLRETURN EsSQLBindParameter(
 	DBGH(stmt, "succesfully bound parameter #%hu, IO-type: %hd, "
 		"SQL C type: %hd, SQL type: %hd, size: %llu, decdigits: %hd, "
 		"buffer@0x%p, length: %lld, LenInd@0x%p.", ParameterNumber,
-		InputOutputType, ValueType, ParameterType, ColumnSize, DecimalDigits,
-		ParameterValuePtr, BufferLength, StrLen_or_IndPtr);
+		InputOutputType, ValueType, ParameterType, (uint64_t)ColumnSize,
+		DecimalDigits, ParameterValuePtr, (int64_t)BufferLength,
+		StrLen_or_IndPtr);
 
 	return SQL_SUCCESS;
 
@@ -3870,7 +3872,7 @@ SQLRETURN EsSQLDescribeColW(
 	}
 	*pcbColDef = get_col_size(rec);
 	DBGH(stmt, "col #%d of meta type %d has size=%llu.",
-		icol, rec->meta_type, *pcbColDef);
+		icol, rec->meta_type, (uint64_t)*pcbColDef);
 
 	if (! pibScale) {
 		ERRH(stmt, "no column decimal digits buffer provided.");

--- a/driver/tracing.h
+++ b/driver/tracing.h
@@ -77,11 +77,11 @@
 				/* SQL[U]LEN = [unsigned] long OR [u]int64_t (64b _WIN32) */ \
 			case 'n': /* long/int64_t signed */ \
 				_n = snprintf(_BUFF + _ps, _AVAIL(_ps), "%lld", \
-						val ? *(int64_t *)(uintptr_t)val : 0); \
+						val ? (int64_t)*(SQLLEN *)(uintptr_t)val : 0); \
 				break; \
 			case 'N': /* long/int64_t unsigned */ \
 				_n = snprintf(_BUFF + _ps, _AVAIL(_ps), "%llu", \
-						val ? *(uint64_t *)(uintptr_t)val : 0); \
+						val ? (int64_t)*(SQLULEN *)(uintptr_t)val : 0); \
 				break; \
 				/*
 				 * non-numeric pointers

--- a/driver/tracing.h
+++ b/driver/tracing.h
@@ -81,7 +81,7 @@
 				break; \
 			case 'N': /* long/int64_t unsigned */ \
 				_n = snprintf(_BUFF + _ps, _AVAIL(_ps), "%llu", \
-						val ? (int64_t)*(SQLULEN *)(uintptr_t)val : 0); \
+						val ? (uint64_t)*(SQLULEN *)(uintptr_t)val : 0); \
 				break; \
 				/*
 				 * non-numeric pointers


### PR DESCRIPTION
This fixes the debug printing of SQL(U)LEN variable types.
This type is defined as a `long` on WIN32, but a `__int64` on WIN64.
The "%llu"/"%lld" specifier had been used from the start, before the need
for an x86 driver was considered and stayed like that mostly since.

The values logged by an x86 drivers contains the actual values of the
variable, but one needs to convert to hexa, remove the upper 4 byte and
convert back to decimal, which is cumbersome.

The values are now promoted to a `(u)int64_t` in the logging statements,
so printf will always log the correct value.

This change also updates some other few incorrect specifiers.