### PR TITLE
Update CMake generation for Visual Studio 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ On the server side, the requirements follow Elasticsearch SQL's requirements.
 The project is CMake enabled, which generates the environment-dependent build
 pipeline. This is a general build requirement.
 
-The building itself is then delegated to the platform-specific tools (MSVC or
-make).
+The building itself is then delegated to the platform-specific tools.
+
+CMake 3.14 or newer is required for building with Visual Studio 2019.
 
 ### External libraries/headers
 
@@ -75,9 +76,9 @@ The required libraries are added as subtrees to the project, in the libs directo
 Building the driver requires the installation of Microsoft tools. These can be
 from the Visual Studio pack or with the [standalone tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
 
-Version 2017 Enterprise 15 is used to develop with, older versions
+Version 2019 Enterprise 16 is used to develop with, older versions
 should work fine too, with their corresponding modules. The lists of packages
-for MSVC 2017 are given below.
+for MSVC 2019 are given below.
 
 Required packages:
 

--- a/build.bat
+++ b/build.bat
@@ -525,7 +525,7 @@ REM generator string to feed CMake
 		echo %~nx0: ERROR: no Visual Studio edition detected (%VSCMD_VER%^).
 		echo %~nx0:        Retry running with 'setup' argument.
 		echo.
-		goto END
+		exit /b 1
 	)
 
 	goto:eof
@@ -541,6 +541,9 @@ REM BUILD function: build various targets
 		echo %~nx0: generating the project files.
 
 		call:SETGENERATOR
+		if ERRORLEVEL 1 (
+			goto:END
+		)
 
 		set CMAKE_ARGS=-DDRIVER_BASE_NAME=%DRIVER_BASE_NAME%
 		set CMAKE_ARGS=!CMAKE_ARGS! -G !VS_GENERATOR! -A %TARCH:x86=Win32%

--- a/build.bat
+++ b/build.bat
@@ -385,7 +385,7 @@ REM SETUP function: set-up the build environment
 		)
 	)
 	if [%VS_YEAR%] == [] (
-		set VS_YEARS=2019 2018
+		set VS_YEARS=2019 2017
 	) else (
 		set VS_YEARS=%VS_YEAR%
 	)

--- a/build.bat
+++ b/build.bat
@@ -308,7 +308,6 @@ REM USAGE function: output a usage message
 	echo                  param (needs Administrator privileges^).
 	echo    regdel      : deregister the driver from the registry;
 	echo                  (needs Administrator privileges^).
-	echo    tests       : (deprecated^) synonym with utests.
 	echo.
 	goto:eof
 
@@ -376,7 +375,7 @@ REM CLEAN function: clean up the build dir.
 
 REM SETUP function: set-up the build environment
 :SETUP
-	set RELEASE=2017
+	set RELEASE=2019
 	for %%e in (Enterprise, Professional, Community) do (
 		if exist "C:\Program Files (x86)\Microsoft Visual Studio\%RELEASE%\%%e\Common7\Tools\VsDevCmd.bat" (
 			if /i "%%e" == "Community" (
@@ -507,8 +506,9 @@ REM BUILD function: build various targets
 		rem call:BUILDTYPE
 
 		set CMAKE_ARGS=-DDRIVER_BASE_NAME=%DRIVER_BASE_NAME%
-		REM no explicit x86 generator and is the default (MSVC2017 only?).
-		set CMAKE_ARGS=!CMAKE_ARGS! -DCMAKE_GENERATOR_PLATFORM=%TARCH:x86=%
+		REM CMAKE_GENERATOR_TOOLSET (or cmake -T v142) to specify a toolset
+		REM cmake's architecture specs for MSVC are x64 and Win32
+		set CMAKE_ARGS=!CMAKE_ARGS! -DCMAKE_GENERATOR_PLATFORM=!TARCH:x86=Win32!
 
 		if /i [!BUILD_TYPE!] == [Debug] (
 			set CMAKE_ARGS=!CMAKE_ARGS! -DLIBCURL_BUILD_TYPE=debug
@@ -530,13 +530,7 @@ REM BUILD function: build various targets
 		goto:eof
 	)
 
-	if /i not [%ARG: tests=%] == [%ARG%] ( REM utests dup'd
-		echo %~nx0: building all the project.
-		MSBuild ALL_BUILD.vcxproj %MSBUILD_ARGS%
-		if ERRORLEVEL 1 (
-			goto END
-		)
-	) else if /i not [%ARG:utests=%] == [%ARG%] (
+	if /i not [%ARG:utests=%] == [%ARG%] (
 		echo %~nx0: building all the project.
 		MSBuild ALL_BUILD.vcxproj %MSBUILD_ARGS%
 		if ERRORLEVEL 1 (
@@ -588,12 +582,7 @@ REM BUILD function: build various targets
 
 REM TESTS_SUITE_S function: run the compiled unit tests
 :TESTS_SUITE_S
-	if /i not [%ARG: tests=%] == [%ARG%] ( REM utests dup'd
-		MSBuild RUN_TESTS.vcxproj !MSBUILD_ARGS!
-		if ERRORLEVEL 1 (
-			goto END
-		)
-	) else if /i not [%ARG:utests=%] == [%ARG%] (
+	if /i not [%ARG:utests=%] == [%ARG%] (
 		MSBuild RUN_TESTS.vcxproj !MSBUILD_ARGS!
 		if ERRORLEVEL 1 (
 			goto END


### PR DESCRIPTION
Update the CMake generator specs to build with Visual Studio 2019 16 or Visual Studio 2017 15.
The `setup` argument now also takes a year to select between the two versions (ex: `setup:2017`); if none is provided, setting up the environment is sequentially attempted with the two versions above, in the given order.

CMake 3.14 or newer is required for VS2019.

The PR also removes the deprecated `tests` argument.

Closes #248.

Depends on https://github.com/elastic/infra/issues/22063.