### PR TITLE
Add a build.sh so installer can be build in *nix systems

### DIFF
--- a/installer/build.sh
+++ b/installer/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+FAKE="packages/build/FAKE.x64/tools/FAKE.exe"
+BUILDSCRIPT="build/scripts/Targets.fsx"
+FAKE_NO_LEGACY_WARNING=true
+
+mono .paket/paket.bootstrapper.exe
+if [[ -f .paket.lock ]]; then mono .paket/paket.exe restore; fi
+if [[ ! -f .paket.lock ]]; then mono .paket/paket.exe install; fi
+mono $FAKE --removeLegacyFakeWarning $BUILDSCRIPT "cmdline=$*" --fsiargs -d:MONO

--- a/installer/build/scripts/Commandline.fsx
+++ b/installer/build/scripts/Commandline.fsx
@@ -3,12 +3,12 @@
 // you may not use this file except in compliance with the Elastic License.
 
 #I "../../packages/build/FAKE.x64/tools"
-#I @"../../packages/build/Fsharp.Data/lib/net45"
+#I @"../../packages/build/FSharp.Data/lib/net45"
 #I @"../../packages/build/FSharp.Text.RegexProvider/lib/net40"
 
 #r "FakeLib.dll"
-#r "Fsharp.Data.dll"
-#r "Fsharp.Text.RegexProvider.dll"
+#r "FSharp.Data.dll"
+#r "FSharp.Text.RegexProvider.dll"
 
 #load "Products.fsx"
 


### PR DESCRIPTION
This also fixes some case sensitive references that were incorrectly
cased and will therefor not be found on *nix systems.