### PR TITLE
Testing convenience: build testing DSN out of a provided ES URL

### DIFF
--- a/test/integration/data.py
+++ b/test/integration/data.py
@@ -517,6 +517,8 @@ class TestData(object):
 			self._del_resource(url)
 
 	def _load_tableau_sample(self, file_name, index_name, template, pipeline=None):
+		# function will build meta-data, needed also for the MODE_NOINDEX testing
+		ndjsons = self._get_csv_as_ndjson(TABLEAU_DATASET_BASE_URL, file_name, index_name)
 		if self._mode <= self.MODE_NOINDEX:
 			return
 		self._delete_if_needed(index_name, True, pipeline is not None)
@@ -534,7 +536,6 @@ class TestData(object):
 					raise Exception("PUT %s pipeline failed with code: %s (content: %s) " % (index_name,
 						req.status_code, req.text))
 
-		ndjsons = self._get_csv_as_ndjson(TABLEAU_DATASET_BASE_URL, file_name, index_name)
 		self._post_ndjson(ndjsons, index_name, index_name if pipeline else None)
 		self._wait_for_results(index_name)
 

--- a/test/integration/testing.py
+++ b/test/integration/testing.py
@@ -10,6 +10,7 @@ import unittest
 import re
 import struct
 import ctypes
+import urllib3
 
 from elasticsearch import Elasticsearch
 from data import TestData, BATTERS_TEMPLATE
@@ -27,12 +28,14 @@ class Testing(unittest.TestCase):
 	def __init__(self, es, test_data, catalog, dsn=None):
 		super().__init__()
 		uid, pwd = es.credentials()
+		es_url = urllib3.util.parse_url(es.base_url())
 
 		self._uid = uid
 		self._data = test_data
 		self._catalog = catalog
 
-		conn_str = "Driver={%s};UID=%s;PWD=%s;Secure=0;" % (DRIVER_NAME, uid, pwd)
+		conn_str = "Driver={%s};UID=%s;PWD=%s;Server=%s;Port=%s;Secure=%s;" % (DRIVER_NAME, uid, pwd, es_url.host,
+				es_url.port, "1" if es_url.scheme.lower() == "https" else "0")
 		if dsn:
 			if "Driver=" not in dsn:
 				self._dsn = conn_str + dsn


### PR DESCRIPTION
Fixes for running the integration testing app as an ES data provisioning tool:

* In case the '-p' parameter provides a URL to connect to a running
Elasticsearch instance, use that to construct a testing DSN, so another
(and possibly conflicting) '-c' paramter won't need to.

* This also fixes a defect where trying to run the integration suite in
non-indexing mode fails due to missing meta-data.