### PR TITLE
Add catalog support

### DIFF
--- a/driver/catalogue.c
+++ b/driver/catalogue.c
@@ -87,35 +87,52 @@ SQLRETURN EsSQLStatisticsW(
 	return fake_answer(hstmt, &statistics);
 }
 
-BOOL TEST_API set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog)
+void free_current_catalog(esodbc_dbc_st *dbc)
 {
-	if (dbc->catalog.cnt) {
-		DBGH(dbc, "catalog already set to `" LWPDL "`.", LWSTR(&dbc->catalog));
-		if (! EQ_WSTR(&dbc->catalog, catalog)) {
-			/* this should never happen, as cluster's name is not updateable
-			 * on the fly. */
-			ERRH(dbc, "overwriting previously set catalog value!");
-			free(dbc->catalog.str);
-			dbc->catalog.str = NULL;
-			dbc->catalog.cnt = 0;
-		} else {
-			return FALSE;
+	if (dbc->catalog.w.str) {
+		free(dbc->catalog.w.str);
+		dbc->catalog.w.str = NULL;
+		dbc->catalog.w.cnt = 0;
+	}
+	if (dbc->catalog.c.str) {
+		free(dbc->catalog.c.str);
+		dbc->catalog.c.str = NULL;
+		dbc->catalog.c.cnt = 0;
+	}
+}
+
+SQLRETURN set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog)
+{
+	if (dbc->catalog.w.cnt) {
+		DBGH(dbc, "catalog previously set to `" LWPDL "`.",
+			LWSTR(&dbc->catalog.w));
+		if (! EQ_WSTR(&dbc->catalog.w, catalog)) {
+			free_current_catalog(dbc);
 		}
 	}
-	if (! catalog->cnt) {
-		WARNH(dbc, "attempting to set catalog name to empty value.");
-		return FALSE;
+	if (! catalog->cnt || ! catalog->str) {
+		WARNH(dbc, "catalog name set to empty value.");
+		return SQL_SUCCESS;
 	}
-	if (! (dbc->catalog.str = malloc((catalog->cnt + 1) * sizeof(SQLWCHAR)))) {
+	dbc->catalog.w.str = malloc((catalog->cnt + 1) * sizeof(SQLWCHAR));
+	if (! dbc->catalog.w.str) {
 		ERRNH(dbc, "OOM for %zu wchars.", catalog->cnt + 1);
-		return FALSE;
+		RET_HDIAGS(dbc, SQL_STATE_HY001);
 	}
-	wmemcpy(dbc->catalog.str, catalog->str, catalog->cnt);
-	dbc->catalog.str[catalog->cnt] = L'\0';
-	dbc->catalog.cnt = catalog->cnt;
-	INFOH(dbc, "current catalog name: `" LWPDL "`.", LWSTR(&dbc->catalog));
+	wmemcpy(dbc->catalog.w.str, catalog->str, catalog->cnt);
+	dbc->catalog.w.str[catalog->cnt] = L'\0';
+	dbc->catalog.w.cnt = catalog->cnt;
 
-	return TRUE;
+	if (! wstr_to_utf8(catalog, &dbc->catalog.c)) {
+		goto err;
+	}
+
+	INFOH(dbc, "current catalog name: `" LWPDL "`.", LWSTR(&dbc->catalog.w));
+	return SQL_SUCCESS;
+
+err:
+	free_current_catalog(dbc);
+	RET_HDIAG(dbc, SQL_STATE_HY000, "Saving current catalog failed", 0);
 }
 
 /* writes into 'dest', of size 'room', the current requested attr. of 'dbc'.
@@ -197,9 +214,6 @@ SQLSMALLINT fetch_server_attr(esodbc_dbc_st *dbc, SQLINTEGER attr_id,
 			attr_val.cnt = ind_len / sizeof(*buff);
 			/* 0-term room left out when binding */
 			buff[attr_val.cnt] = L'\0'; /* write_wstr() expects the 0-term */
-		}
-		if (attr_id == SQL_ATTR_CURRENT_CATALOG) {
-			set_current_catalog(dbc, &attr_val);
 		}
 	}
 	DBGH(dbc, "attribute %ld value: `" LWPDL "`.", attr_id, LWSTR(&attr_val));

--- a/driver/catalogue.h
+++ b/driver/catalogue.h
@@ -35,7 +35,8 @@ enum {
 
 SQLSMALLINT fetch_server_attr(esodbc_dbc_st *dbc, SQLINTEGER attr_id,
 	SQLWCHAR *dest, SQLSMALLINT room);
-BOOL TEST_API set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog);
+SQLRETURN set_current_catalog(esodbc_dbc_st *dbc, wstr_st *catalog);
+void free_current_catalog(esodbc_dbc_st *dbc);
 SQLRETURN TEST_API update_varchar_defs(esodbc_stmt_st *stmt);
 
 

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -131,7 +131,6 @@ typedef struct struct_dbc {
 
 	wstr_st dsn; /* data source name SQLGetInfo(SQL_DATA_SOURCE_NAME) */
 	wstr_st server; /* ~ name; requested with SQLGetInfo(SQL_SERVER_NAME) */
-	wstr_st catalog; /* cached value; checked against if app setting it */
 	wstr_st srv_ver; /* server version: SQLGetInfo(SQL_DBMS_VER) */
 
 	cstr_st proxy_url;
@@ -166,6 +165,10 @@ typedef struct struct_dbc {
 		ESODBC_CMPSS_AUTO,
 	} compression;
 	BOOL apply_tz; /* should the times be converted from UTC to local TZ? */
+	struct {
+		wstr_st w; /* NB: w.str and c.str are co-allocated */
+		cstr_st c;
+	} catalog; /* current ~  */
 	BOOL early_exec; /* should prepared, non-param queries be exec'd early? */
 	enum {
 		ESODBC_FLTS_DEFAULT = 0,
@@ -559,7 +562,7 @@ SQLRETURN EsSQLSetDescRec(
 /* return the code associated with the given state (and debug-log) */
 #define RET_STATE(_s)	\
 	do { \
-		assert(_s < SQL_STATE_MAX); \
+		assert(SQL_STATE_00000 <= _s && _s < SQL_STATE_MAX); \
 		return esodbc_errors[_s].retcode; \
 	} while (0)
 

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -142,12 +142,15 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define REQ_KEY_MULTIVAL		"field_multi_value_leniency"
 #define REQ_KEY_IDX_FROZEN		"index_include_frozen"
 #define REQ_KEY_TIMEZONE		"time_zone"
+#define REQ_KEY_CATALOG			"catalog"
 #define REQ_KEY_BINARY_FMT		"binary_format"
+
+#define REST_REQ_KEY_COUNT		13 /* "query" / "cursor" count as one */
+
 /* keys for the "params" argument */
 #define REQ_KEY_PARAM_TYPE		"type"
 #define REQ_KEY_PARAM_VAL		"value"
 
-#define REST_REQ_KEY_COUNT		11 /* "query" or "cursor" */
 
 #ifdef _WIN64
 #	define REQ_VAL_CLT_ID		"odbc64"
@@ -172,6 +175,7 @@ SQLRETURN EsSQLRowCount(_In_ SQLHSTMT StatementHandle, _Out_ SQLLEN *RowCount);
 #define JSON_KEY_MULTIVAL		", \"" REQ_KEY_MULTIVAL "\": " /* n-th */
 #define JSON_KEY_IDX_FROZEN		", \"" REQ_KEY_IDX_FROZEN "\": " /* n-th */
 #define JSON_KEY_TIMEZONE		", \"" REQ_KEY_TIMEZONE "\": " /* n-th key */
+#define JSON_KEY_CATALOG		", \"" REQ_KEY_CATALOG "\": " /* n-th key */
 #define JSON_KEY_BINARY_FMT		", \"" REQ_KEY_BINARY_FMT "\": " /* n-th key */
 
 #define JSON_VAL_TIMEZONE_Z		"\"" REQ_VAL_TIMEZONE_Z "\""

--- a/test/test_driverconnect.cc
+++ b/test/test_driverconnect.cc
@@ -74,23 +74,28 @@ TEST_F(DriverConnect, OutputTruncated)
 
 }
 
-TEST_F(DriverConnect, ReinitCurrentCatalog)
+TEST_F(DriverConnect, ConnectWithDefaultCatalog)
 {
-	ret = SQLDriverConnect(my_dbc, (SQLHWND)&types, (SQLWCHAR *)CONNECT_STRING,
-		sizeof(CONNECT_STRING) / sizeof(CONNECT_STRING[0]) - 1, NULL, 0,
+#	define MY_CATALOG					"my_catalog"
+#	define CONNECT_STR_CAT	CONNECT_STRING "Catalog=" MY_CATALOG ";"
+
+	ret = SQLDriverConnect(my_dbc, (SQLHWND)&types, (SQLWCHAR *)CONNECT_STR_CAT,
+		sizeof(CONNECT_STR_CAT) / sizeof(CONNECT_STR_CAT[0]) - 1, NULL, 0,
 		&out_avail, ESODBC_SQL_DRIVER_TEST);
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
-	esodbc_dbc_st *dbc = (esodbc_dbc_st *)my_dbc;
-	wstr_st crr_cat = WSTR_INIT("crr_catalog");
-	ASSERT_TRUE(set_current_catalog(dbc, &crr_cat));
-	ASSERT_FALSE(set_current_catalog(dbc, &crr_cat));
+	SQLWCHAR buff[sizeof(CONNECT_STR_CAT)];
+	SQLINTEGER len;
+	ASSERT_TRUE(SQL_SUCCEEDED(SQLGetConnectAttrW(my_dbc,
+					SQL_ATTR_CURRENT_CATALOG, (SQLPOINTER)buff, sizeof(buff), &len)));
+	ASSERT_STREQ(MK_WPTR(MY_CATALOG), buff);
+	ASSERT_EQ(sizeof(MY_CATALOG) - /*\0*/1, len);
 
-	wstr_st other_cat = WSTR_INIT("other_catalog");
-	ASSERT_TRUE(set_current_catalog(dbc, &other_cat));
+#	undef CONNECT_STR_CAT
+#	undef MY_CATALOG
 }
 
-TEST_F(DriverConnect, ResetCurrentCatalog)
+TEST_F(DriverConnect, SetResetUnsetCurrentCatalog)
 {
 	ret = SQLDriverConnect(my_dbc, (SQLHWND)&types, (SQLWCHAR *)CONNECT_STRING,
 		sizeof(CONNECT_STRING) / sizeof(CONNECT_STRING[0]) - 1, NULL, 0,
@@ -98,16 +103,51 @@ TEST_F(DriverConnect, ResetCurrentCatalog)
 	ASSERT_TRUE(SQL_SUCCEEDED(ret));
 
 	esodbc_dbc_st *dbc = (esodbc_dbc_st *)my_dbc;
-	wstr_st crr_cat = WSTR_INIT("crr_catalog");
-	ASSERT_TRUE(set_current_catalog(dbc, &crr_cat));
+	ASSERT_EQ(NULL, dbc->catalog.w.str);
+	ASSERT_EQ(0, dbc->catalog.w.cnt);
+	ASSERT_EQ(NULL, dbc->catalog.c.str);
+	ASSERT_EQ(0, dbc->catalog.c.cnt);
+
+	//
+	// Set
+	//
+	wstr_st crr_cat = WSTR_INIT("current_catalog");
 	ASSERT_TRUE(SQL_SUCCEEDED(SQLSetConnectAttrW(my_dbc,
 					SQL_ATTR_CURRENT_CATALOG, (SQLPOINTER)crr_cat.str,
 					(SQLINTEGER)(crr_cat.cnt * sizeof(SQLWCHAR)))));
 
+	SQLWCHAR buff[32]; // accomodates 'other_cat' too
+	ASSERT_GT(sizeof(buff)/sizeof(*buff), crr_cat.cnt + /*\0*/1);
+	SQLINTEGER len;
+	ASSERT_TRUE(SQL_SUCCEEDED(SQLGetConnectAttrW(my_dbc,
+					SQL_ATTR_CURRENT_CATALOG, (SQLPOINTER)buff, sizeof(buff), &len)));
+	ASSERT_STREQ(crr_cat.str, buff);
+	ASSERT_EQ(crr_cat.cnt, len);
+
+	//
+	// Reset
+	//
 	wstr_st other_cat = WSTR_INIT("other_catalog");
-	ASSERT_FALSE(SQL_SUCCEEDED(SQLSetConnectAttrW(my_dbc,
+	ASSERT_TRUE(SQL_SUCCEEDED(SQLSetConnectAttrW(my_dbc,
 					SQL_ATTR_CURRENT_CATALOG, (SQLPOINTER)other_cat.str,
 					(SQLINTEGER)(other_cat.cnt * sizeof(SQLWCHAR)))));
+
+	ASSERT_GT(sizeof(buff)/sizeof(*buff), other_cat.cnt + /*\0*/1);
+	ASSERT_TRUE(SQL_SUCCEEDED(SQLGetConnectAttrW(my_dbc,
+					SQL_ATTR_CURRENT_CATALOG, (SQLPOINTER)buff, sizeof(buff), &len)));
+	ASSERT_STREQ(other_cat.str, buff);
+	ASSERT_EQ(other_cat.cnt, len);
+
+	//
+	// Unset
+	//
+	ASSERT_TRUE(SQL_SUCCEEDED(SQLSetConnectAttrW(my_dbc,
+					SQL_ATTR_CURRENT_CATALOG, NULL, 0)));
+	/* SQLGetConnectAttrW() would now trigger a `SELECT database()` */
+	ASSERT_EQ(NULL, dbc->catalog.w.str);
+	ASSERT_EQ(0, dbc->catalog.w.cnt);
+	ASSERT_EQ(NULL, dbc->catalog.c.str);
+	ASSERT_EQ(0, dbc->catalog.c.cnt);
 }
 
 } // test namespace


### PR DESCRIPTION
This adds support for multiple catalogs ("databases").
The client application can now set the catalog at connection level -
with SQLSetConnectAttr - to a pattern matching a local or remote cluster
name and ES/SQL will execute the query on the respective cluster/s.

A default catalog can also be set through the connection string, through
the "Catalog" DSN attribute.

In case the catalog is not set, or set to an empty or null string, the
local catalog will be chosen for execution.

The driver will simply add a "catalog" request attribute containing the
value received from the application, or skip adding the attribute if
this is empty.

Relates to https://github.com/elastic/elasticsearch/pull/78903.