### PR TITLE
Fix SQLDescribeCol numeric attribute param handling 

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -1503,7 +1503,7 @@ SQLRETURN config_dbc(esodbc_dbc_st *dbc, esodbc_dsn_attrs_st *attrs)
 	INFOH(dbc, "early execution: %s.", dbc->early_exec ? "true" : "false");
 	/* default current catalog */
 	if (attrs->catalog.cnt &&
-			(! SQL_SUCCEEDED(set_current_catalog(dbc, &attrs->catalog)))) {
+		(! SQL_SUCCEEDED(set_current_catalog(dbc, &attrs->catalog)))) {
 		goto err;
 	}
 
@@ -3478,8 +3478,8 @@ SQLRETURN EsSQLGetConnectAttrW(
 			}
 			if (dbc->catalog.w.cnt) {
 				if (! SQL_SUCCEEDED(write_wstr(dbc, (SQLWCHAR *)ValuePtr,
-								&dbc->catalog.w, (SQLSMALLINT)BufferLength,
-								&used))) {
+							&dbc->catalog.w, (SQLSMALLINT)BufferLength,
+							&used))) {
 					ERRH(dbc, "failed to copy current catalog out.");
 					RET_STATE(dbc->hdr.diag.state);
 				}

--- a/driver/odbc.c
+++ b/driver/odbc.c
@@ -837,13 +837,8 @@ SQLRETURN SQL_API SQLColAttributeW
 	ret = EsSQLColAttributeW(hstmt, iCol, iField, pCharAttr,
 			cbDescMax, pcbCharAttr, pNumAttr);
 	HND_UNLOCK(hstmt);
-#ifdef _WIN64
 	TRACE8(_OUT, hstmt, "dpHHphtn", ret, hstmt, iCol, iField, pCharAttr,
 		cbDescMax, pcbCharAttr, pNumAttr);
-#else /* _WIN64 */
-	TRACE8(_OUT, hstmt, "dpddpdtg", ret, hstmt, iCol, iField, pCharAttr,
-		cbDescMax, pcbCharAttr, pNumAttr);
-#endif /* _WIN64 */
 	return ret;
 }
 

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -3957,11 +3957,7 @@ SQLRETURN EsSQLColAttributeW(
 	_Out_opt_
 	SQLSMALLINT     *pcbCharAttr, /* [out] len written in pCharAttr (w/o \0 */
 	_Out_opt_
-#ifdef _WIN64
 	SQLLEN          *pNumAttr /* [out] value, if numeric */
-#else /* _WIN64 */
-	SQLPOINTER      pNumAttr
-#endif /* _WIN64 */
 )
 {
 	esodbc_stmt_st *stmt = STMH(hstmt);
@@ -3971,12 +3967,6 @@ SQLRETURN EsSQLColAttributeW(
 	wstr_st *wstrp;
 	SQLLEN len;
 	SQLINTEGER iint;
-
-#ifdef _WIN64
-#define PNUMATTR_ASSIGN(type, value) *pNumAttr = (SQLLEN)(value)
-#else /* _WIN64 */
-#define PNUMATTR_ASSIGN(type, value) *(type *)pNumAttr = (type)(value)
-#endif /* _WIN64 */
 
 	DBGH(stmt, "IRD@0x%p, column #%d, field: %d.", ird, iCol, iField);
 
@@ -4022,7 +4012,7 @@ SQLRETURN EsSQLColAttributeW(
 			sint = rec->es_type->fixed_prec_scale;
 			break;
 		} while (0);
-			PNUMATTR_ASSIGN(SQLSMALLINT, sint);
+			*pNumAttr = (SQLLEN)sint;
 			break;
 
 		/* SQLWCHAR* */
@@ -4056,14 +4046,14 @@ SQLRETURN EsSQLColAttributeW(
 		case SQL_COLUMN_LENGTH: /* 2.x attrib; no break */
 		case SQL_DESC_OCTET_LENGTH: len = rec->octet_length; break;
 		} while (0);
-			PNUMATTR_ASSIGN(SQLLEN, len);
+			*pNumAttr = len;
 			break;
 
 		/* SQLULEN */
 		case SQL_DESC_LENGTH:
 			/* "This information is returned from the SQL_DESC_LENGTH record
 			 * field of the IRD." */
-			PNUMATTR_ASSIGN(SQLULEN, rec->length);
+			*pNumAttr = (SQLLEN)rec->length;
 			break;
 
 		/* SQLINTEGER */
@@ -4076,12 +4066,12 @@ SQLRETURN EsSQLColAttributeW(
 			break;
 		case SQL_DESC_NUM_PREC_RADIX: iint = rec->num_prec_radix; break;
 		} while (0);
-			PNUMATTR_ASSIGN(SQLINTEGER, iint);
+			*pNumAttr = (SQLLEN)iint;
 			break;
 
 
 		case SQL_DESC_COUNT:
-			PNUMATTR_ASSIGN(SQLSMALLINT, ird->count);
+			*pNumAttr = (SQLLEN)ird->count;
 			break;
 
 		default:
@@ -4091,7 +4081,6 @@ SQLRETURN EsSQLColAttributeW(
 	/*INDENT-ON*/
 
 	return SQL_SUCCESS;
-#undef PNUMATTR_ASSIGN
 }
 
 /* very simple counter of non-quoted, not-escaped single question marks.

--- a/driver/queries.c
+++ b/driver/queries.c
@@ -4064,7 +4064,9 @@ SQLRETURN EsSQLColAttributeW(
 		case SQL_DESC_CASE_SENSITIVE:
 			iint = rec->es_type->case_sensitive;
 			break;
-		case SQL_DESC_NUM_PREC_RADIX: iint = rec->num_prec_radix; break;
+		case SQL_DESC_NUM_PREC_RADIX:
+			iint = rec->es_type->num_prec_radix;
+			break;
 		} while (0);
 			*pNumAttr = (SQLLEN)iint;
 			break;

--- a/driver/queries.h
+++ b/driver/queries.h
@@ -115,11 +115,7 @@ SQLRETURN EsSQLColAttributeW(
 	_Out_opt_
 	SQLSMALLINT     *pcbCharAttr,
 	_Out_opt_
-#ifdef _WIN64
 	SQLLEN          *pNumAttr
-#else /* _WIN64 */
-	SQLPOINTER      pNumAttr
-#endif /* _WIN64 */
 );
 SQLRETURN EsSQLNumParams(
 	SQLHSTMT           StatementHandle,

--- a/test/test_colattribute.cc
+++ b/test/test_colattribute.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <gtest/gtest.h>
+#include "connected_dbc.h"
+
+#include <string.h>
+#include <math.h>
+
+/* placeholders; will be undef'd and redef'd */
+#define SQL_SCALE
+#define SQL_RAW
+#define SQL_VAL
+#define SQL /* attached for troubleshooting purposes */
+
+namespace test {
+
+class ColAttribute : public ::testing::Test, public ConnectedDBC {
+};
+
+
+TEST_F(ColAttribute, NumericAttributePtr_SQLSMALLINT) {
+	SQLLEN pNumAttr;
+
+#undef SQL_VAL
+#undef SQL
+#define SQL_VAL "0.98765432100123456789" //20 fractional digits
+#define SQL "CAST(" SQL_VAL " AS SCALED_FLOAT)"
+
+	const char json_answer[] = "\
+{\
+  \"columns\": [\
+    {\"name\": \"" SQL "\", \"type\": \"scaled_float\"}\
+  ],\
+  \"rows\": [\
+    [" SQL_VAL "]\
+  ]\
+}\
+";
+	prepareStatement(json_answer);
+
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	memset(&pNumAttr, 0xff, sizeof(pNumAttr));
+	ret = SQLColAttribute(stmt, 1, SQL_DESC_CONCISE_TYPE, NULL, 0, NULL,
+			&pNumAttr);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ASSERT_EQ(pNumAttr, SQL_C_DOUBLE);
+}
+
+TEST_F(ColAttribute, NumericAttributePtr_SQLLEN) {
+	SQLLEN pNumAttr;
+
+#undef SQL_VAL
+#undef SQL
+#define SQL_VAL "0.98765432100123456789" //20 fractional digits
+#define SQL "CAST(" SQL_VAL " AS SCALED_FLOAT)"
+
+	const char json_answer[] = "\
+{\
+  \"columns\": [\
+    {\"name\": \"" SQL "\", \"type\": \"scaled_float\"}\
+  ],\
+  \"rows\": [\
+    [" SQL_VAL "]\
+  ]\
+}\
+";
+	prepareStatement(json_answer);
+
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	memset(&pNumAttr, 0xff, sizeof(pNumAttr));
+	ret = SQLColAttribute(stmt, 1, SQL_DESC_DISPLAY_SIZE, NULL, 0, NULL,
+			&pNumAttr);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	// https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size
+	// "SQL_FLOAT, SQL_DOUBLE: 24 (a sign, 15 digits, a decimal point, the
+	// letter E, a sign, and 3 digits)."
+	ASSERT_EQ(pNumAttr, 24);
+}
+
+TEST_F(ColAttribute, NumericAttributePtr_SQLULEN) {
+	SQLLEN pNumAttr;
+
+#undef SQL_VAL
+#undef SQL
+#define SQL_VAL "0.98765432100123456789" //20 fractional digits
+#define SQL "CAST(" SQL_VAL " AS SCALED_FLOAT)"
+
+	const char json_answer[] = "\
+{\
+  \"columns\": [\
+    {\"name\": \"" SQL "\", \"type\": \"scaled_float\"}\
+  ],\
+  \"rows\": [\
+    [" SQL_VAL "]\
+  ]\
+}\
+";
+	prepareStatement(json_answer);
+
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	memset(&pNumAttr, 0xff, sizeof(pNumAttr));
+	ret = SQLColAttribute(stmt, 1, SQL_DESC_LENGTH, NULL, 0, NULL, &pNumAttr);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	ASSERT_EQ(pNumAttr, 0);
+}
+
+TEST_F(ColAttribute, NumericAttributePtr_SQLINTEGER) {
+	SQLLEN pNumAttr;
+
+#undef SQL_VAL
+#undef SQL
+#define SQL_VAL "0.98765432100123456789" //20 fractional digits
+#define SQL "CAST(" SQL_VAL " AS SCALED_FLOAT)"
+
+	const char json_answer[] = "\
+{\
+  \"columns\": [\
+    {\"name\": \"" SQL "\", \"type\": \"scaled_float\"}\
+  ],\
+  \"rows\": [\
+    [" SQL_VAL "]\
+  ]\
+}\
+";
+	prepareStatement(json_answer);
+
+	ret = SQLFetch(stmt);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+	memset(&pNumAttr, 0xff, sizeof(pNumAttr));
+	ret = SQLColAttribute(stmt, 1, SQL_DESC_NUM_PREC_RADIX, NULL, 0, NULL,
+			&pNumAttr);
+	ASSERT_TRUE(SQL_SUCCEEDED(ret));
+	// https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function
+	// "If the data type is an approximate numeric type, this column contains
+	// the value 2 to indicate that COLUMN_SIZE specifies a number of bits."
+	ASSERT_EQ(pNumAttr, 2);
+}
+
+
+
+
+} // test namespace
+


### PR DESCRIPTION
The last parameter of SQLDescribeCol(), the "NumericAttributePtr" is an
out parameter that should always point to a SQLLEN value (for both x64
and x32 builds), despite this value being assigned different width
values.

The x32 API definition uses a "void *" that would allow passing pointers
to various width integers, but the spec does require an SQLLEN and other
drivers and apps aligned to it. Some apps seem however to not cast down
to the width corresponding to the various attributes, which can lead to
incorrect behavior. The driver now scales up all values to an SQLLEN.

Also, returning of the SQL_DESC_NUM_PREC_RADIX attribute is
corrected.