### PR TITLE
Add support for API Key authentication

### DIFF
--- a/driver/dsn.c
+++ b/driver/dsn.c
@@ -33,7 +33,8 @@ void TEST_API init_dsn_attrs(esodbc_dsn_attrs_st *attrs)
 static inline wstr_st *mask_pwd(wstr_st *attr, wstr_st *val)
 {
 	static wstr_st subst = WSTR_INIT(ESODBC_PWD_VAL_SUBST);
-	return EQ_CASE_WSTR(attr, &MK_WSTR(ESODBC_DSN_PWD)) ? &subst : val;
+	return EQ_CASE_WSTR(attr, &MK_WSTR(ESODBC_DSN_PWD)) ||
+		EQ_CASE_WSTR(attr, &MK_WSTR(ESODBC_DSN_API_KEY)) ? &subst : val;
 }
 
 #define DSN_NOT_MATCHED		0
@@ -61,6 +62,7 @@ int assign_dsn_attr(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_DSN), &attrs->dsn},
 		{&MK_WSTR(ESODBC_DSN_PWD), &attrs->pwd},
 		{&MK_WSTR(ESODBC_DSN_UID), &attrs->uid},
+		{&MK_WSTR(ESODBC_DSN_API_KEY), &attrs->api_key},
 		{&MK_WSTR(ESODBC_DSN_SAVEFILE), &attrs->savefile},
 		{&MK_WSTR(ESODBC_DSN_FILEDSN), &attrs->filedsn},
 		{&MK_WSTR(ESODBC_DSN_CLOUD_ID), &attrs->cloud_id},
@@ -404,6 +406,7 @@ long TEST_API write_00_list(esodbc_dsn_attrs_st *attrs,
 		{&MK_WSTR(ESODBC_DSN_DSN), &attrs->dsn},
 		{&MK_WSTR(ESODBC_DSN_PWD), &attrs->pwd},
 		{&MK_WSTR(ESODBC_DSN_UID), &attrs->uid},
+		{&MK_WSTR(ESODBC_DSN_API_KEY), &attrs->api_key},
 		{&MK_WSTR(ESODBC_DSN_SAVEFILE), &attrs->savefile},
 		{&MK_WSTR(ESODBC_DSN_FILEDSN), &attrs->filedsn},
 		{&MK_WSTR(ESODBC_DSN_CLOUD_ID), &attrs->cloud_id},
@@ -637,6 +640,10 @@ BOOL write_system_dsn(esodbc_dsn_attrs_st *new_attrs,
 			&MK_WSTR(ESODBC_DSN_UID), &new_attrs->uid,
 			old_attrs ? &old_attrs->uid : NULL
 		},
+		{
+			&MK_WSTR(ESODBC_DSN_API_KEY), &new_attrs->api_key,
+			old_attrs ? &old_attrs->api_key : NULL
+		},
 		/* SAVEILE */
 		/* FILEDSN */
 		{
@@ -819,6 +826,7 @@ long TEST_API write_connection_string(esodbc_dsn_attrs_st *attrs,
 		{&attrs->dsn, &MK_WSTR(ESODBC_DSN_DSN)},
 		{&attrs->pwd, &MK_WSTR(ESODBC_DSN_PWD)},
 		{&attrs->uid, &MK_WSTR(ESODBC_DSN_UID)},
+		{&attrs->api_key, &MK_WSTR(ESODBC_DSN_API_KEY)},
 		{&attrs->savefile, &MK_WSTR(ESODBC_DSN_SAVEFILE)},
 		{&attrs->filedsn, &MK_WSTR(ESODBC_DSN_FILEDSN)},
 		{&attrs->cloud_id, &MK_WSTR(ESODBC_DSN_CLOUD_ID)},

--- a/driver/dsn.h
+++ b/driver/dsn.h
@@ -20,6 +20,7 @@
 #define ESODBC_DSN_DSN				"DSN"
 #define ESODBC_DSN_PWD				"PWD"
 #define ESODBC_DSN_UID				"UID"
+#define ESODBC_DSN_API_KEY			"APIKey"
 #define ESODBC_DSN_SAVEFILE			"SAVEFILE"
 #define ESODBC_DSN_FILEDSN			"FILEDSN"
 #define ESODBC_DSN_CLOUD_ID			"CloudID"
@@ -71,6 +72,7 @@ typedef struct {
 	wstr_st dsn;
 	wstr_st pwd;
 	wstr_st uid;
+	wstr_st api_key;
 	wstr_st savefile;
 	wstr_st filedsn;
 	wstr_st cloud_id;
@@ -102,7 +104,7 @@ typedef struct {
 	wstr_st trace_enabled;
 	wstr_st trace_file;
 	wstr_st trace_level;
-#define ESODBC_DSN_ATTRS_COUNT	36
+#define ESODBC_DSN_ATTRS_COUNT	37
 
 	SQLWCHAR buff[ESODBC_DSN_ATTRS_COUNT * ESODBC_DSN_MAX_ATTR_LEN];
 	/* DSN reading/writing functions are passed a SQLSMALLINT length param */

--- a/driver/handles.h
+++ b/driver/handles.h
@@ -150,7 +150,10 @@ typedef struct struct_dbc {
 	cstr_st ca_path;
 
 	cstr_st uid;
-	cstr_st pwd;
+	union {
+		cstr_st pwd; /* when dbc configuring, pwd is only set if uid is */
+		cstr_st api_key;
+	};
 	SQLUINTEGER timeout;
 	BOOL follow;
 	struct {
@@ -204,6 +207,7 @@ typedef struct struct_dbc {
 	size_t apos; /* current write position in the abuff */
 	size_t amax; /* maximum length (bytes) that abuff can grow to */
 	esodbc_mutex_lt curl_mux; /* mutex for above 'networking' members */
+	struct curl_slist *curl_hdrs; /* HTTP headers list */
 
 	/* window handler */
 	HWND hwin;

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.Designer.cs
@@ -110,6 +110,8 @@ namespace EsOdbcDsnEditor
             this.textCertificatePath = new System.Windows.Forms.TextBox();
             this.labelCertificatePath = new System.Windows.Forms.Label();
             this.pageBasic = new System.Windows.Forms.TabPage();
+            this.textApiKey = new System.Windows.Forms.TextBox();
+            this.labelApiKey = new System.Windows.Forms.Label();
             this.labelCloudID = new System.Windows.Forms.Label();
             this.textDescription = new System.Windows.Forms.TextBox();
             this.textCloudID = new System.Windows.Forms.TextBox();
@@ -145,6 +147,7 @@ namespace EsOdbcDsnEditor
             this.toolTipProxyAuthEnabled = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipProxyUsername = new System.Windows.Forms.ToolTip(this.components);
             this.toolTipProxyPassword = new System.Windows.Forms.ToolTip(this.components);
+            this.toolTipApiKey = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.header)).BeginInit();
             this.pageLogging.SuspendLayout();
             this.pageMisc.SuspendLayout();
@@ -163,10 +166,10 @@ namespace EsOdbcDsnEditor
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(628, 812);
-            this.saveButton.Margin = new System.Windows.Forms.Padding(6);
+            this.saveButton.Location = new System.Drawing.Point(457, 541);
+            this.saveButton.Margin = new System.Windows.Forms.Padding(4);
             this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(138, 42);
+            this.saveButton.Size = new System.Drawing.Size(100, 28);
             this.saveButton.TabIndex = 17;
             this.saveButton.Text = "Save";
             this.saveButton.UseVisualStyleBackColor = true;
@@ -174,10 +177,10 @@ namespace EsOdbcDsnEditor
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(770, 812);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(6);
+            this.cancelButton.Location = new System.Drawing.Point(560, 541);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(4);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(138, 42);
+            this.cancelButton.Size = new System.Drawing.Size(100, 28);
             this.cancelButton.TabIndex = 18;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -185,10 +188,10 @@ namespace EsOdbcDsnEditor
             // 
             // testButton
             // 
-            this.testButton.Location = new System.Drawing.Point(23, 812);
-            this.testButton.Margin = new System.Windows.Forms.Padding(6);
+            this.testButton.Location = new System.Drawing.Point(17, 541);
+            this.testButton.Margin = new System.Windows.Forms.Padding(4);
             this.testButton.Name = "testButton";
-            this.testButton.Size = new System.Drawing.Size(214, 42);
+            this.testButton.Size = new System.Drawing.Size(156, 28);
             this.testButton.TabIndex = 16;
             this.testButton.Text = "Test Connection";
             this.testButton.UseVisualStyleBackColor = true;
@@ -202,7 +205,7 @@ namespace EsOdbcDsnEditor
             this.header.Location = new System.Drawing.Point(0, 0);
             this.header.Margin = new System.Windows.Forms.Padding(0);
             this.header.Name = "header";
-            this.header.Size = new System.Drawing.Size(935, 87);
+            this.header.Size = new System.Drawing.Size(680, 58);
             this.header.TabIndex = 5;
             this.header.TabStop = false;
             // 
@@ -218,11 +221,11 @@ namespace EsOdbcDsnEditor
             this.pageLogging.Controls.Add(this.logDirectoryPathButton);
             this.pageLogging.Controls.Add(this.textLogDirectoryPath);
             this.pageLogging.Controls.Add(this.labelLogDirectory);
-            this.pageLogging.Location = new System.Drawing.Point(4, 33);
-            this.pageLogging.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.pageLogging.Location = new System.Drawing.Point(4, 25);
+            this.pageLogging.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.pageLogging.Name = "pageLogging";
-            this.pageLogging.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.pageLogging.Size = new System.Drawing.Size(883, 653);
+            this.pageLogging.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pageLogging.Size = new System.Drawing.Size(640, 431);
             this.pageLogging.TabIndex = 2;
             this.pageLogging.Text = "Logging";
             this.pageLogging.UseVisualStyleBackColor = true;
@@ -232,10 +235,10 @@ namespace EsOdbcDsnEditor
             this.checkLoggingEnabled.AutoSize = true;
             this.checkLoggingEnabled.Checked = true;
             this.checkLoggingEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkLoggingEnabled.Location = new System.Drawing.Point(22, 32);
-            this.checkLoggingEnabled.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkLoggingEnabled.Location = new System.Drawing.Point(16, 21);
+            this.checkLoggingEnabled.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkLoggingEnabled.Name = "checkLoggingEnabled";
-            this.checkLoggingEnabled.Size = new System.Drawing.Size(174, 29);
+            this.checkLoggingEnabled.Size = new System.Drawing.Size(129, 21);
             this.checkLoggingEnabled.TabIndex = 22;
             this.checkLoggingEnabled.Text = "Enable Logging";
             this.checkLoggingEnabled.UseVisualStyleBackColor = true;
@@ -250,28 +253,27 @@ namespace EsOdbcDsnEditor
             "INFO",
             "WARN",
             "ERROR"});
-            this.comboLogLevel.Location = new System.Drawing.Point(170, 147);
-            this.comboLogLevel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboLogLevel.Location = new System.Drawing.Point(124, 98);
+            this.comboLogLevel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboLogLevel.Name = "comboLogLevel";
-            this.comboLogLevel.Size = new System.Drawing.Size(147, 32);
+            this.comboLogLevel.Size = new System.Drawing.Size(108, 24);
             this.comboLogLevel.TabIndex = 25;
             // 
             // labelLogLevel
             // 
             this.labelLogLevel.AutoSize = true;
-            this.labelLogLevel.Location = new System.Drawing.Point(22, 152);
-            this.labelLogLevel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelLogLevel.Location = new System.Drawing.Point(16, 101);
             this.labelLogLevel.Name = "labelLogLevel";
-            this.labelLogLevel.Size = new System.Drawing.Size(103, 25);
+            this.labelLogLevel.Size = new System.Drawing.Size(74, 17);
             this.labelLogLevel.TabIndex = 20;
             this.labelLogLevel.Text = "Log Level:";
             // 
             // logDirectoryPathButton
             // 
-            this.logDirectoryPathButton.Location = new System.Drawing.Point(723, 82);
-            this.logDirectoryPathButton.Margin = new System.Windows.Forms.Padding(6);
+            this.logDirectoryPathButton.Location = new System.Drawing.Point(526, 55);
+            this.logDirectoryPathButton.Margin = new System.Windows.Forms.Padding(4);
             this.logDirectoryPathButton.Name = "logDirectoryPathButton";
-            this.logDirectoryPathButton.Size = new System.Drawing.Size(138, 42);
+            this.logDirectoryPathButton.Size = new System.Drawing.Size(100, 28);
             this.logDirectoryPathButton.TabIndex = 24;
             this.logDirectoryPathButton.Text = "Browse...";
             this.logDirectoryPathButton.UseVisualStyleBackColor = true;
@@ -279,20 +281,19 @@ namespace EsOdbcDsnEditor
             // 
             // textLogDirectoryPath
             // 
-            this.textLogDirectoryPath.Location = new System.Drawing.Point(170, 86);
-            this.textLogDirectoryPath.Margin = new System.Windows.Forms.Padding(6);
+            this.textLogDirectoryPath.Location = new System.Drawing.Point(124, 57);
+            this.textLogDirectoryPath.Margin = new System.Windows.Forms.Padding(4);
             this.textLogDirectoryPath.MaxLength = 512;
             this.textLogDirectoryPath.Name = "textLogDirectoryPath";
-            this.textLogDirectoryPath.Size = new System.Drawing.Size(538, 29);
+            this.textLogDirectoryPath.Size = new System.Drawing.Size(392, 22);
             this.textLogDirectoryPath.TabIndex = 23;
             // 
             // labelLogDirectory
             // 
             this.labelLogDirectory.AutoSize = true;
-            this.labelLogDirectory.Location = new System.Drawing.Point(22, 93);
-            this.labelLogDirectory.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelLogDirectory.Location = new System.Drawing.Point(16, 62);
             this.labelLogDirectory.Name = "labelLogDirectory";
-            this.labelLogDirectory.Size = new System.Drawing.Size(133, 25);
+            this.labelLogDirectory.Size = new System.Drawing.Size(97, 17);
             this.labelLogDirectory.TabIndex = 16;
             this.labelLogDirectory.Text = "Log Directory:";
             // 
@@ -318,11 +319,10 @@ namespace EsOdbcDsnEditor
             this.pageMisc.Controls.Add(this.numericUpDownFetchSize);
             this.pageMisc.Controls.Add(this.labelTimeout);
             this.pageMisc.Controls.Add(this.numericUpDownTimeout);
-            this.pageMisc.Location = new System.Drawing.Point(4, 33);
-            this.pageMisc.Margin = new System.Windows.Forms.Padding(4);
+            this.pageMisc.Location = new System.Drawing.Point(4, 25);
             this.pageMisc.Name = "pageMisc";
-            this.pageMisc.Padding = new System.Windows.Forms.Padding(4);
-            this.pageMisc.Size = new System.Drawing.Size(883, 653);
+            this.pageMisc.Padding = new System.Windows.Forms.Padding(3);
+            this.pageMisc.Size = new System.Drawing.Size(640, 431);
             this.pageMisc.TabIndex = 3;
             this.pageMisc.Text = "Misc";
             this.pageMisc.UseVisualStyleBackColor = true;
@@ -330,24 +330,22 @@ namespace EsOdbcDsnEditor
             // labelVarcharLimit
             // 
             this.labelVarcharLimit.AutoSize = true;
-            this.labelVarcharLimit.Location = new System.Drawing.Point(33, 184);
-            this.labelVarcharLimit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelVarcharLimit.Location = new System.Drawing.Point(24, 123);
             this.labelVarcharLimit.Name = "labelVarcharLimit";
-            this.labelVarcharLimit.Size = new System.Drawing.Size(132, 25);
+            this.labelVarcharLimit.Size = new System.Drawing.Size(95, 17);
             this.labelVarcharLimit.TabIndex = 12;
             this.labelVarcharLimit.Text = "Varchar Limit:";
             // 
             // numericUpDownVarcharLimit
             // 
-            this.numericUpDownVarcharLimit.Location = new System.Drawing.Point(250, 182);
-            this.numericUpDownVarcharLimit.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownVarcharLimit.Location = new System.Drawing.Point(182, 121);
             this.numericUpDownVarcharLimit.Maximum = new decimal(new int[] {
             32766,
             0,
             0,
             0});
             this.numericUpDownVarcharLimit.Name = "numericUpDownVarcharLimit";
-            this.numericUpDownVarcharLimit.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownVarcharLimit.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownVarcharLimit.TabIndex = 13;
             // 
             // checkBoxEarlyExecution
@@ -355,10 +353,10 @@ namespace EsOdbcDsnEditor
             this.checkBoxEarlyExecution.AutoSize = true;
             this.checkBoxEarlyExecution.Checked = true;
             this.checkBoxEarlyExecution.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxEarlyExecution.Location = new System.Drawing.Point(465, 286);
-            this.checkBoxEarlyExecution.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxEarlyExecution.Location = new System.Drawing.Point(338, 191);
+            this.checkBoxEarlyExecution.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxEarlyExecution.Name = "checkBoxEarlyExecution";
-            this.checkBoxEarlyExecution.Size = new System.Drawing.Size(232, 29);
+            this.checkBoxEarlyExecution.Size = new System.Drawing.Size(170, 21);
             this.checkBoxEarlyExecution.TabIndex = 18;
             this.checkBoxEarlyExecution.Text = "Early Query Execution";
             this.checkBoxEarlyExecution.UseVisualStyleBackColor = true;
@@ -371,19 +369,18 @@ namespace EsOdbcDsnEditor
             "auto",
             "on",
             "off"});
-            this.comboBoxDataCompression.Location = new System.Drawing.Point(250, 340);
-            this.comboBoxDataCompression.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxDataCompression.Location = new System.Drawing.Point(182, 227);
+            this.comboBoxDataCompression.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxDataCompression.Name = "comboBoxDataCompression";
-            this.comboBoxDataCompression.Size = new System.Drawing.Size(147, 32);
+            this.comboBoxDataCompression.Size = new System.Drawing.Size(108, 24);
             this.comboBoxDataCompression.TabIndex = 19;
             // 
             // labelDataCompression
             // 
             this.labelDataCompression.AutoSize = true;
-            this.labelDataCompression.Location = new System.Drawing.Point(33, 351);
-            this.labelDataCompression.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelDataCompression.Location = new System.Drawing.Point(24, 234);
             this.labelDataCompression.Name = "labelDataCompression";
-            this.labelDataCompression.Size = new System.Drawing.Size(175, 25);
+            this.labelDataCompression.Size = new System.Drawing.Size(126, 17);
             this.labelDataCompression.TabIndex = 18;
             this.labelDataCompression.Text = "Data compression:";
             // 
@@ -394,19 +391,18 @@ namespace EsOdbcDsnEditor
             this.comboBoxDataEncoding.Items.AddRange(new object[] {
             "CBOR",
             "JSON"});
-            this.comboBoxDataEncoding.Location = new System.Drawing.Point(250, 286);
-            this.comboBoxDataEncoding.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxDataEncoding.Location = new System.Drawing.Point(182, 191);
+            this.comboBoxDataEncoding.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxDataEncoding.Name = "comboBoxDataEncoding";
-            this.comboBoxDataEncoding.Size = new System.Drawing.Size(147, 32);
+            this.comboBoxDataEncoding.Size = new System.Drawing.Size(108, 24);
             this.comboBoxDataEncoding.TabIndex = 17;
             // 
             // labelDataEncoding
             // 
             this.labelDataEncoding.AutoSize = true;
-            this.labelDataEncoding.Location = new System.Drawing.Point(33, 291);
-            this.labelDataEncoding.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelDataEncoding.Location = new System.Drawing.Point(24, 194);
             this.labelDataEncoding.Name = "labelDataEncoding";
-            this.labelDataEncoding.Size = new System.Drawing.Size(144, 25);
+            this.labelDataEncoding.Size = new System.Drawing.Size(104, 17);
             this.labelDataEncoding.TabIndex = 16;
             this.labelDataEncoding.Text = "Data encoding:";
             // 
@@ -415,10 +411,10 @@ namespace EsOdbcDsnEditor
             this.checkBoxAutoEscapePVA.AutoSize = true;
             this.checkBoxAutoEscapePVA.Checked = true;
             this.checkBoxAutoEscapePVA.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxAutoEscapePVA.Location = new System.Drawing.Point(466, 129);
-            this.checkBoxAutoEscapePVA.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxAutoEscapePVA.Location = new System.Drawing.Point(339, 86);
+            this.checkBoxAutoEscapePVA.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxAutoEscapePVA.Name = "checkBoxAutoEscapePVA";
-            this.checkBoxAutoEscapePVA.Size = new System.Drawing.Size(206, 29);
+            this.checkBoxAutoEscapePVA.Size = new System.Drawing.Size(148, 21);
             this.checkBoxAutoEscapePVA.TabIndex = 12;
             this.checkBoxAutoEscapePVA.Text = "Auto-escape PVAs";
             this.checkBoxAutoEscapePVA.UseVisualStyleBackColor = true;
@@ -431,29 +427,28 @@ namespace EsOdbcDsnEditor
             "default",
             "scientific",
             "auto"});
-            this.comboBoxFloatsFormat.Location = new System.Drawing.Point(250, 232);
-            this.comboBoxFloatsFormat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxFloatsFormat.Location = new System.Drawing.Point(182, 155);
+            this.comboBoxFloatsFormat.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxFloatsFormat.Name = "comboBoxFloatsFormat";
-            this.comboBoxFloatsFormat.Size = new System.Drawing.Size(147, 32);
+            this.comboBoxFloatsFormat.Size = new System.Drawing.Size(108, 24);
             this.comboBoxFloatsFormat.TabIndex = 15;
             // 
             // labelFloatsFormat
             // 
             this.labelFloatsFormat.AutoSize = true;
-            this.labelFloatsFormat.Location = new System.Drawing.Point(33, 237);
-            this.labelFloatsFormat.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelFloatsFormat.Location = new System.Drawing.Point(24, 158);
             this.labelFloatsFormat.Name = "labelFloatsFormat";
-            this.labelFloatsFormat.Size = new System.Drawing.Size(130, 25);
+            this.labelFloatsFormat.Size = new System.Drawing.Size(94, 17);
             this.labelFloatsFormat.TabIndex = 14;
             this.labelFloatsFormat.Text = "Floats format:";
             // 
             // checkBoxIndexIncludeFrozen
             // 
             this.checkBoxIndexIncludeFrozen.AutoSize = true;
-            this.checkBoxIndexIncludeFrozen.Location = new System.Drawing.Point(466, 231);
-            this.checkBoxIndexIncludeFrozen.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxIndexIncludeFrozen.Location = new System.Drawing.Point(339, 154);
+            this.checkBoxIndexIncludeFrozen.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxIndexIncludeFrozen.Name = "checkBoxIndexIncludeFrozen";
-            this.checkBoxIndexIncludeFrozen.Size = new System.Drawing.Size(226, 29);
+            this.checkBoxIndexIncludeFrozen.Size = new System.Drawing.Size(167, 21);
             this.checkBoxIndexIncludeFrozen.TabIndex = 16;
             this.checkBoxIndexIncludeFrozen.Text = "Include frozen indices";
             this.checkBoxIndexIncludeFrozen.UseVisualStyleBackColor = true;
@@ -463,10 +458,10 @@ namespace EsOdbcDsnEditor
             this.checkBoxMultiFieldLenient.AutoSize = true;
             this.checkBoxMultiFieldLenient.Checked = true;
             this.checkBoxMultiFieldLenient.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxMultiFieldLenient.Location = new System.Drawing.Point(466, 178);
-            this.checkBoxMultiFieldLenient.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxMultiFieldLenient.Location = new System.Drawing.Point(339, 119);
+            this.checkBoxMultiFieldLenient.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxMultiFieldLenient.Name = "checkBoxMultiFieldLenient";
-            this.checkBoxMultiFieldLenient.Size = new System.Drawing.Size(233, 29);
+            this.checkBoxMultiFieldLenient.Size = new System.Drawing.Size(173, 21);
             this.checkBoxMultiFieldLenient.TabIndex = 14;
             this.checkBoxMultiFieldLenient.Text = "Multi value field lenient";
             this.checkBoxMultiFieldLenient.UseVisualStyleBackColor = true;
@@ -474,10 +469,10 @@ namespace EsOdbcDsnEditor
             // checkBoxApplyTZ
             // 
             this.checkBoxApplyTZ.AutoSize = true;
-            this.checkBoxApplyTZ.Location = new System.Drawing.Point(466, 80);
-            this.checkBoxApplyTZ.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxApplyTZ.Location = new System.Drawing.Point(339, 53);
+            this.checkBoxApplyTZ.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxApplyTZ.Name = "checkBoxApplyTZ";
-            this.checkBoxApplyTZ.Size = new System.Drawing.Size(202, 29);
+            this.checkBoxApplyTZ.Size = new System.Drawing.Size(149, 21);
             this.checkBoxApplyTZ.TabIndex = 10;
             this.checkBoxApplyTZ.Text = "Use local timezone";
             this.checkBoxApplyTZ.UseVisualStyleBackColor = true;
@@ -487,10 +482,10 @@ namespace EsOdbcDsnEditor
             this.checkBoxFollowRedirects.AutoSize = true;
             this.checkBoxFollowRedirects.Checked = true;
             this.checkBoxFollowRedirects.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxFollowRedirects.Location = new System.Drawing.Point(466, 30);
-            this.checkBoxFollowRedirects.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkBoxFollowRedirects.Location = new System.Drawing.Point(339, 20);
+            this.checkBoxFollowRedirects.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxFollowRedirects.Name = "checkBoxFollowRedirects";
-            this.checkBoxFollowRedirects.Size = new System.Drawing.Size(231, 29);
+            this.checkBoxFollowRedirects.Size = new System.Drawing.Size(169, 21);
             this.checkBoxFollowRedirects.TabIndex = 8;
             this.checkBoxFollowRedirects.Text = "Follow HTTP redirects";
             this.checkBoxFollowRedirects.UseVisualStyleBackColor = true;
@@ -498,24 +493,22 @@ namespace EsOdbcDsnEditor
             // labelBodySize
             // 
             this.labelBodySize.AutoSize = true;
-            this.labelBodySize.Location = new System.Drawing.Point(33, 132);
-            this.labelBodySize.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelBodySize.Location = new System.Drawing.Point(24, 88);
             this.labelBodySize.Name = "labelBodySize";
-            this.labelBodySize.Size = new System.Drawing.Size(212, 25);
+            this.labelBodySize.Size = new System.Drawing.Size(150, 17);
             this.labelBodySize.TabIndex = 10;
             this.labelBodySize.Text = "Max page length (MB):";
             // 
             // numericUpDownBodySize
             // 
-            this.numericUpDownBodySize.Location = new System.Drawing.Point(250, 129);
-            this.numericUpDownBodySize.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownBodySize.Location = new System.Drawing.Point(182, 86);
             this.numericUpDownBodySize.Maximum = new decimal(new int[] {
             -1,
             0,
             0,
             0});
             this.numericUpDownBodySize.Name = "numericUpDownBodySize";
-            this.numericUpDownBodySize.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownBodySize.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownBodySize.TabIndex = 11;
             this.numericUpDownBodySize.Value = new decimal(new int[] {
             100,
@@ -526,10 +519,9 @@ namespace EsOdbcDsnEditor
             // labelFetchSize
             // 
             this.labelFetchSize.AutoSize = true;
-            this.labelFetchSize.Location = new System.Drawing.Point(33, 80);
-            this.labelFetchSize.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelFetchSize.Location = new System.Drawing.Point(24, 53);
             this.labelFetchSize.Name = "labelFetchSize";
-            this.labelFetchSize.Size = new System.Drawing.Size(205, 25);
+            this.labelFetchSize.Size = new System.Drawing.Size(145, 17);
             this.labelFetchSize.TabIndex = 8;
             this.labelFetchSize.Text = "Max page size (rows):";
             // 
@@ -540,15 +532,14 @@ namespace EsOdbcDsnEditor
             0,
             0,
             0});
-            this.numericUpDownFetchSize.Location = new System.Drawing.Point(250, 76);
-            this.numericUpDownFetchSize.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownFetchSize.Location = new System.Drawing.Point(182, 51);
             this.numericUpDownFetchSize.Maximum = new decimal(new int[] {
             -1,
             0,
             0,
             0});
             this.numericUpDownFetchSize.Name = "numericUpDownFetchSize";
-            this.numericUpDownFetchSize.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownFetchSize.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownFetchSize.TabIndex = 9;
             this.numericUpDownFetchSize.Value = new decimal(new int[] {
             1000,
@@ -559,24 +550,22 @@ namespace EsOdbcDsnEditor
             // labelTimeout
             // 
             this.labelTimeout.AutoSize = true;
-            this.labelTimeout.Location = new System.Drawing.Point(33, 30);
-            this.labelTimeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelTimeout.Location = new System.Drawing.Point(24, 20);
             this.labelTimeout.Name = "labelTimeout";
-            this.labelTimeout.Size = new System.Drawing.Size(187, 25);
+            this.labelTimeout.Size = new System.Drawing.Size(136, 17);
             this.labelTimeout.TabIndex = 6;
             this.labelTimeout.Text = "Request timeout (s):";
             // 
             // numericUpDownTimeout
             // 
-            this.numericUpDownTimeout.Location = new System.Drawing.Point(250, 27);
-            this.numericUpDownTimeout.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownTimeout.Location = new System.Drawing.Point(182, 18);
             this.numericUpDownTimeout.Maximum = new decimal(new int[] {
             -1,
             0,
             0,
             0});
             this.numericUpDownTimeout.Name = "numericUpDownTimeout";
-            this.numericUpDownTimeout.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownTimeout.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownTimeout.TabIndex = 7;
             // 
             // pageSecurity
@@ -585,21 +574,20 @@ namespace EsOdbcDsnEditor
             this.pageSecurity.Controls.Add(this.groupSSL);
             this.pageSecurity.Controls.Add(this.textCertificatePath);
             this.pageSecurity.Controls.Add(this.labelCertificatePath);
-            this.pageSecurity.Location = new System.Drawing.Point(4, 33);
-            this.pageSecurity.Margin = new System.Windows.Forms.Padding(4);
+            this.pageSecurity.Location = new System.Drawing.Point(4, 25);
             this.pageSecurity.Name = "pageSecurity";
-            this.pageSecurity.Padding = new System.Windows.Forms.Padding(4);
-            this.pageSecurity.Size = new System.Drawing.Size(883, 653);
+            this.pageSecurity.Padding = new System.Windows.Forms.Padding(3);
+            this.pageSecurity.Size = new System.Drawing.Size(640, 431);
             this.pageSecurity.TabIndex = 1;
             this.pageSecurity.Text = "Security";
             this.pageSecurity.UseVisualStyleBackColor = true;
             // 
             // certificatePathButton
             // 
-            this.certificatePathButton.Location = new System.Drawing.Point(720, 309);
-            this.certificatePathButton.Margin = new System.Windows.Forms.Padding(6);
+            this.certificatePathButton.Location = new System.Drawing.Point(524, 206);
+            this.certificatePathButton.Margin = new System.Windows.Forms.Padding(4);
             this.certificatePathButton.Name = "certificatePathButton";
-            this.certificatePathButton.Size = new System.Drawing.Size(138, 42);
+            this.certificatePathButton.Size = new System.Drawing.Size(100, 28);
             this.certificatePathButton.TabIndex = 15;
             this.certificatePathButton.Text = "Browse...";
             this.certificatePathButton.UseVisualStyleBackColor = true;
@@ -612,11 +600,9 @@ namespace EsOdbcDsnEditor
             this.groupSSL.Controls.Add(this.radioEnabledNoHostname);
             this.groupSSL.Controls.Add(this.radioEnabledNoValidation);
             this.groupSSL.Controls.Add(this.radioButtonDisabled);
-            this.groupSSL.Location = new System.Drawing.Point(22, 24);
-            this.groupSSL.Margin = new System.Windows.Forms.Padding(4);
+            this.groupSSL.Location = new System.Drawing.Point(16, 16);
             this.groupSSL.Name = "groupSSL";
-            this.groupSSL.Padding = new System.Windows.Forms.Padding(4);
-            this.groupSSL.Size = new System.Drawing.Size(836, 264);
+            this.groupSSL.Size = new System.Drawing.Size(608, 176);
             this.groupSSL.TabIndex = 10;
             this.groupSSL.TabStop = false;
             this.groupSSL.Text = "Secure Sockets Layer (SSL):";
@@ -624,10 +610,9 @@ namespace EsOdbcDsnEditor
             // radioEnabledFull
             // 
             this.radioEnabledFull.AutoSize = true;
-            this.radioEnabledFull.Location = new System.Drawing.Point(22, 208);
-            this.radioEnabledFull.Margin = new System.Windows.Forms.Padding(4);
+            this.radioEnabledFull.Location = new System.Drawing.Point(16, 139);
             this.radioEnabledFull.Name = "radioEnabledFull";
-            this.radioEnabledFull.Size = new System.Drawing.Size(412, 29);
+            this.radioEnabledFull.Size = new System.Drawing.Size(304, 21);
             this.radioEnabledFull.TabIndex = 13;
             this.radioEnabledFull.TabStop = true;
             this.radioEnabledFull.Text = "Enabled. Certificate identity chain validated.";
@@ -636,10 +621,9 @@ namespace EsOdbcDsnEditor
             // radioEnabledHostname
             // 
             this.radioEnabledHostname.AutoSize = true;
-            this.radioEnabledHostname.Location = new System.Drawing.Point(22, 168);
-            this.radioEnabledHostname.Margin = new System.Windows.Forms.Padding(4);
+            this.radioEnabledHostname.Location = new System.Drawing.Point(16, 112);
             this.radioEnabledHostname.Name = "radioEnabledHostname";
-            this.radioEnabledHostname.Size = new System.Drawing.Size(493, 29);
+            this.radioEnabledHostname.Size = new System.Drawing.Size(362, 21);
             this.radioEnabledHostname.TabIndex = 12;
             this.radioEnabledHostname.TabStop = true;
             this.radioEnabledHostname.Text = "Enabled. Certificate is validated; hostname validated.";
@@ -648,10 +632,9 @@ namespace EsOdbcDsnEditor
             // radioEnabledNoHostname
             // 
             this.radioEnabledNoHostname.AutoSize = true;
-            this.radioEnabledNoHostname.Location = new System.Drawing.Point(22, 128);
-            this.radioEnabledNoHostname.Margin = new System.Windows.Forms.Padding(4);
+            this.radioEnabledNoHostname.Location = new System.Drawing.Point(16, 85);
             this.radioEnabledNoHostname.Name = "radioEnabledNoHostname";
-            this.radioEnabledNoHostname.Size = new System.Drawing.Size(525, 29);
+            this.radioEnabledNoHostname.Size = new System.Drawing.Size(386, 21);
             this.radioEnabledNoHostname.TabIndex = 11;
             this.radioEnabledNoHostname.TabStop = true;
             this.radioEnabledNoHostname.Text = "Enabled. Certificate is validated; hostname not validated.";
@@ -660,10 +643,9 @@ namespace EsOdbcDsnEditor
             // radioEnabledNoValidation
             // 
             this.radioEnabledNoValidation.AutoSize = true;
-            this.radioEnabledNoValidation.Location = new System.Drawing.Point(22, 87);
-            this.radioEnabledNoValidation.Margin = new System.Windows.Forms.Padding(4);
+            this.radioEnabledNoValidation.Location = new System.Drawing.Point(16, 58);
             this.radioEnabledNoValidation.Name = "radioEnabledNoValidation";
-            this.radioEnabledNoValidation.Size = new System.Drawing.Size(326, 29);
+            this.radioEnabledNoValidation.Size = new System.Drawing.Size(241, 21);
             this.radioEnabledNoValidation.TabIndex = 10;
             this.radioEnabledNoValidation.TabStop = true;
             this.radioEnabledNoValidation.Text = "Enabled. Certificate not validated.";
@@ -672,10 +654,9 @@ namespace EsOdbcDsnEditor
             // radioButtonDisabled
             // 
             this.radioButtonDisabled.AutoSize = true;
-            this.radioButtonDisabled.Location = new System.Drawing.Point(22, 46);
-            this.radioButtonDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.radioButtonDisabled.Location = new System.Drawing.Point(16, 31);
             this.radioButtonDisabled.Name = "radioButtonDisabled";
-            this.radioButtonDisabled.Size = new System.Drawing.Size(409, 29);
+            this.radioButtonDisabled.Size = new System.Drawing.Size(299, 21);
             this.radioButtonDisabled.TabIndex = 9;
             this.radioButtonDisabled.TabStop = true;
             this.radioButtonDisabled.Text = "Disabled. All communications unencrypted.";
@@ -683,25 +664,26 @@ namespace EsOdbcDsnEditor
             // 
             // textCertificatePath
             // 
-            this.textCertificatePath.Location = new System.Drawing.Point(170, 314);
-            this.textCertificatePath.Margin = new System.Windows.Forms.Padding(6);
+            this.textCertificatePath.Location = new System.Drawing.Point(124, 209);
+            this.textCertificatePath.Margin = new System.Windows.Forms.Padding(4);
             this.textCertificatePath.MaxLength = 512;
             this.textCertificatePath.Name = "textCertificatePath";
-            this.textCertificatePath.Size = new System.Drawing.Size(538, 29);
+            this.textCertificatePath.Size = new System.Drawing.Size(392, 22);
             this.textCertificatePath.TabIndex = 14;
             // 
             // labelCertificatePath
             // 
             this.labelCertificatePath.AutoSize = true;
-            this.labelCertificatePath.Location = new System.Drawing.Point(22, 318);
-            this.labelCertificatePath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelCertificatePath.Location = new System.Drawing.Point(16, 212);
             this.labelCertificatePath.Name = "labelCertificatePath";
-            this.labelCertificatePath.Size = new System.Drawing.Size(141, 25);
+            this.labelCertificatePath.Size = new System.Drawing.Size(101, 17);
             this.labelCertificatePath.TabIndex = 11;
             this.labelCertificatePath.Text = "Certificate File:";
             // 
             // pageBasic
             // 
+            this.pageBasic.Controls.Add(this.textApiKey);
+            this.pageBasic.Controls.Add(this.labelApiKey);
             this.pageBasic.Controls.Add(this.labelCloudID);
             this.pageBasic.Controls.Add(this.textDescription);
             this.pageBasic.Controls.Add(this.textCloudID);
@@ -716,138 +698,151 @@ namespace EsOdbcDsnEditor
             this.pageBasic.Controls.Add(this.labelUsername);
             this.pageBasic.Controls.Add(this.numericUpDownPort);
             this.pageBasic.Controls.Add(this.labelPassword);
-            this.pageBasic.Location = new System.Drawing.Point(4, 33);
-            this.pageBasic.Margin = new System.Windows.Forms.Padding(4);
+            this.pageBasic.Location = new System.Drawing.Point(4, 25);
             this.pageBasic.Name = "pageBasic";
-            this.pageBasic.Padding = new System.Windows.Forms.Padding(4);
-            this.pageBasic.Size = new System.Drawing.Size(883, 653);
+            this.pageBasic.Padding = new System.Windows.Forms.Padding(3);
+            this.pageBasic.Size = new System.Drawing.Size(640, 431);
             this.pageBasic.TabIndex = 0;
             this.pageBasic.Text = "Basic";
             this.pageBasic.UseVisualStyleBackColor = true;
             // 
+            // textApiKey
+            // 
+            this.textApiKey.Location = new System.Drawing.Point(112, 385);
+            this.textApiKey.Margin = new System.Windows.Forms.Padding(4);
+            this.textApiKey.MaxLength = 512;
+            this.textApiKey.Name = "textApiKey";
+            this.textApiKey.Size = new System.Drawing.Size(506, 22);
+            this.textApiKey.TabIndex = 14;
+			this.textApiKey.TextChanged += new System.EventHandler(this.TextApiKey_TextChanged);
+			// 
+			// labelApiKey
+			// 
+			this.labelApiKey.AutoSize = true;
+            this.labelApiKey.Location = new System.Drawing.Point(16, 385);
+            this.labelApiKey.Name = "labelApiKey";
+            this.labelApiKey.Size = new System.Drawing.Size(61, 17);
+            this.labelApiKey.TabIndex = 13;
+            this.labelApiKey.Text = "API Key:";
+            // 
             // labelCloudID
             // 
             this.labelCloudID.AutoSize = true;
-            this.labelCloudID.Location = new System.Drawing.Point(22, 177);
-            this.labelCloudID.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelCloudID.Location = new System.Drawing.Point(16, 118);
             this.labelCloudID.Name = "labelCloudID";
-            this.labelCloudID.Size = new System.Drawing.Size(94, 25);
+            this.labelCloudID.Size = new System.Drawing.Size(65, 17);
             this.labelCloudID.TabIndex = 12;
             this.labelCloudID.Text = "Cloud ID:";
             // 
             // textDescription
             // 
-            this.textDescription.Location = new System.Drawing.Point(154, 84);
-            this.textDescription.Margin = new System.Windows.Forms.Padding(6);
+            this.textDescription.Location = new System.Drawing.Point(112, 56);
+            this.textDescription.Margin = new System.Windows.Forms.Padding(4);
             this.textDescription.MaxLength = 256;
             this.textDescription.Name = "textDescription";
-            this.textDescription.Size = new System.Drawing.Size(694, 29);
+            this.textDescription.Size = new System.Drawing.Size(506, 22);
             this.textDescription.TabIndex = 3;
             // 
             // textCloudID
             // 
-            this.textCloudID.Location = new System.Drawing.Point(154, 172);
-            this.textCloudID.Margin = new System.Windows.Forms.Padding(6);
+            this.textCloudID.Location = new System.Drawing.Point(112, 115);
+            this.textCloudID.Margin = new System.Windows.Forms.Padding(4);
             this.textCloudID.MaxLength = 512;
             this.textCloudID.Multiline = true;
             this.textCloudID.Name = "textCloudID";
-            this.textCloudID.Size = new System.Drawing.Size(694, 106);
+            this.textCloudID.Size = new System.Drawing.Size(506, 72);
             this.textCloudID.TabIndex = 4;
             this.textCloudID.TextChanged += new System.EventHandler(this.TextCloudID_TextChanged);
             // 
             // textName
             // 
-            this.textName.Location = new System.Drawing.Point(154, 27);
-            this.textName.Margin = new System.Windows.Forms.Padding(6);
+            this.textName.Location = new System.Drawing.Point(112, 18);
+            this.textName.Margin = new System.Windows.Forms.Padding(4);
             this.textName.MaxLength = 256;
             this.textName.Name = "textName";
-            this.textName.Size = new System.Drawing.Size(694, 29);
+            this.textName.Size = new System.Drawing.Size(506, 22);
             this.textName.TabIndex = 2;
             this.textName.TextChanged += new System.EventHandler(this.TextName_TextChanged);
             // 
             // textHostname
             // 
-            this.textHostname.Location = new System.Drawing.Point(154, 304);
-            this.textHostname.Margin = new System.Windows.Forms.Padding(6);
+            this.textHostname.Location = new System.Drawing.Point(112, 203);
+            this.textHostname.Margin = new System.Windows.Forms.Padding(4);
             this.textHostname.MaxLength = 512;
             this.textHostname.Name = "textHostname";
-            this.textHostname.Size = new System.Drawing.Size(694, 29);
+            this.textHostname.Size = new System.Drawing.Size(506, 22);
             this.textHostname.TabIndex = 5;
             this.textHostname.TextChanged += new System.EventHandler(this.TextHostname_TextChanged);
             // 
             // textUsername
             // 
-            this.textUsername.Location = new System.Drawing.Point(154, 454);
-            this.textUsername.Margin = new System.Windows.Forms.Padding(6);
+            this.textUsername.Location = new System.Drawing.Point(112, 303);
+            this.textUsername.Margin = new System.Windows.Forms.Padding(4);
             this.textUsername.MaxLength = 512;
             this.textUsername.Name = "textUsername";
-            this.textUsername.Size = new System.Drawing.Size(313, 29);
+            this.textUsername.Size = new System.Drawing.Size(229, 22);
             this.textUsername.TabIndex = 7;
-            // 
-            // textPassword
-            // 
-            this.textPassword.Location = new System.Drawing.Point(154, 514);
-            this.textPassword.Margin = new System.Windows.Forms.Padding(6);
+			this.textUsername.TextChanged += new System.EventHandler(this.TextUsername_TextChanged);
+			// 
+			// textPassword
+			// 
+			this.textPassword.Location = new System.Drawing.Point(112, 343);
+            this.textPassword.Margin = new System.Windows.Forms.Padding(4);
             this.textPassword.MaxLength = 512;
             this.textPassword.Name = "textPassword";
             this.textPassword.PasswordChar = '*';
-            this.textPassword.Size = new System.Drawing.Size(313, 29);
+            this.textPassword.Size = new System.Drawing.Size(229, 22);
             this.textPassword.TabIndex = 8;
-            // 
-            // labelDescription
-            // 
-            this.labelDescription.AutoSize = true;
-            this.labelDescription.Location = new System.Drawing.Point(22, 88);
-            this.labelDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			this.textPassword.TextChanged += new System.EventHandler(this.TextPassword_TextChanged);
+			// 
+			// labelDescription
+			// 
+			this.labelDescription.AutoSize = true;
+            this.labelDescription.Location = new System.Drawing.Point(16, 59);
             this.labelDescription.Name = "labelDescription";
-            this.labelDescription.Size = new System.Drawing.Size(115, 25);
+            this.labelDescription.Size = new System.Drawing.Size(83, 17);
             this.labelDescription.TabIndex = 10;
             this.labelDescription.Text = "Description:";
             // 
             // labelName
             // 
             this.labelName.AutoSize = true;
-            this.labelName.Location = new System.Drawing.Point(22, 32);
-            this.labelName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelName.Location = new System.Drawing.Point(16, 21);
             this.labelName.Name = "labelName";
-            this.labelName.Size = new System.Drawing.Size(70, 25);
+            this.labelName.Size = new System.Drawing.Size(49, 17);
             this.labelName.TabIndex = 8;
             this.labelName.Text = "Name:";
             // 
             // labelHostname
             // 
             this.labelHostname.AutoSize = true;
-            this.labelHostname.Location = new System.Drawing.Point(22, 309);
-            this.labelHostname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelHostname.Location = new System.Drawing.Point(16, 206);
             this.labelHostname.Name = "labelHostname";
-            this.labelHostname.Size = new System.Drawing.Size(107, 25);
+            this.labelHostname.Size = new System.Drawing.Size(76, 17);
             this.labelHostname.TabIndex = 0;
             this.labelHostname.Text = "Hostname:";
             // 
             // labelPort
             // 
             this.labelPort.AutoSize = true;
-            this.labelPort.Location = new System.Drawing.Point(22, 364);
-            this.labelPort.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelPort.Location = new System.Drawing.Point(16, 243);
             this.labelPort.Name = "labelPort";
-            this.labelPort.Size = new System.Drawing.Size(53, 25);
+            this.labelPort.Size = new System.Drawing.Size(38, 17);
             this.labelPort.TabIndex = 2;
             this.labelPort.Text = "Port:";
             // 
             // labelUsername
             // 
             this.labelUsername.AutoSize = true;
-            this.labelUsername.Location = new System.Drawing.Point(22, 459);
-            this.labelUsername.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelUsername.Location = new System.Drawing.Point(16, 306);
             this.labelUsername.Name = "labelUsername";
-            this.labelUsername.Size = new System.Drawing.Size(108, 25);
+            this.labelUsername.Size = new System.Drawing.Size(77, 17);
             this.labelUsername.TabIndex = 4;
             this.labelUsername.Text = "Username:";
             // 
             // numericUpDownPort
             // 
-            this.numericUpDownPort.Location = new System.Drawing.Point(154, 362);
-            this.numericUpDownPort.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownPort.Location = new System.Drawing.Point(112, 241);
             this.numericUpDownPort.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -859,7 +854,7 @@ namespace EsOdbcDsnEditor
             0,
             0});
             this.numericUpDownPort.Name = "numericUpDownPort";
-            this.numericUpDownPort.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownPort.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownPort.TabIndex = 6;
             this.numericUpDownPort.Value = new decimal(new int[] {
             9200,
@@ -871,10 +866,9 @@ namespace EsOdbcDsnEditor
             // labelPassword
             // 
             this.labelPassword.AutoSize = true;
-            this.labelPassword.Location = new System.Drawing.Point(22, 519);
-            this.labelPassword.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelPassword.Location = new System.Drawing.Point(16, 346);
             this.labelPassword.Name = "labelPassword";
-            this.labelPassword.Size = new System.Drawing.Size(104, 25);
+            this.labelPassword.Size = new System.Drawing.Size(73, 17);
             this.labelPassword.TabIndex = 6;
             this.labelPassword.Text = "Password:";
             // 
@@ -885,11 +879,10 @@ namespace EsOdbcDsnEditor
             this.tabConfiguration.Controls.Add(this.pageProxy);
             this.tabConfiguration.Controls.Add(this.pageMisc);
             this.tabConfiguration.Controls.Add(this.pageLogging);
-            this.tabConfiguration.Location = new System.Drawing.Point(23, 111);
-            this.tabConfiguration.Margin = new System.Windows.Forms.Padding(4);
+            this.tabConfiguration.Location = new System.Drawing.Point(17, 74);
             this.tabConfiguration.Name = "tabConfiguration";
             this.tabConfiguration.SelectedIndex = 0;
-            this.tabConfiguration.Size = new System.Drawing.Size(891, 690);
+            this.tabConfiguration.Size = new System.Drawing.Size(648, 460);
             this.tabConfiguration.TabIndex = 8;
             // 
             // pageProxy
@@ -906,50 +899,49 @@ namespace EsOdbcDsnEditor
             this.pageProxy.Controls.Add(this.labelProxyPort);
             this.pageProxy.Controls.Add(this.numericUpDownProxyPort);
             this.pageProxy.Controls.Add(this.checkProxyEnabled);
-            this.pageProxy.Location = new System.Drawing.Point(4, 33);
+            this.pageProxy.Location = new System.Drawing.Point(4, 25);
+            this.pageProxy.Margin = new System.Windows.Forms.Padding(2);
             this.pageProxy.Name = "pageProxy";
-            this.pageProxy.Padding = new System.Windows.Forms.Padding(3);
-            this.pageProxy.Size = new System.Drawing.Size(883, 653);
+            this.pageProxy.Padding = new System.Windows.Forms.Padding(2);
+            this.pageProxy.Size = new System.Drawing.Size(640, 431);
             this.pageProxy.TabIndex = 4;
             this.pageProxy.Text = "Proxy";
             this.pageProxy.UseVisualStyleBackColor = true;
             // 
             // textBoxProxyUsername
             // 
-            this.textBoxProxyUsername.Location = new System.Drawing.Point(166, 355);
-            this.textBoxProxyUsername.Margin = new System.Windows.Forms.Padding(6);
+            this.textBoxProxyUsername.Location = new System.Drawing.Point(121, 237);
+            this.textBoxProxyUsername.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxProxyUsername.MaxLength = 512;
             this.textBoxProxyUsername.Name = "textBoxProxyUsername";
-            this.textBoxProxyUsername.Size = new System.Drawing.Size(313, 29);
+            this.textBoxProxyUsername.Size = new System.Drawing.Size(229, 22);
             this.textBoxProxyUsername.TabIndex = 33;
             // 
             // textBoxProxyPassword
             // 
-            this.textBoxProxyPassword.Location = new System.Drawing.Point(166, 415);
-            this.textBoxProxyPassword.Margin = new System.Windows.Forms.Padding(6);
+            this.textBoxProxyPassword.Location = new System.Drawing.Point(121, 277);
+            this.textBoxProxyPassword.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxProxyPassword.MaxLength = 512;
             this.textBoxProxyPassword.Name = "textBoxProxyPassword";
             this.textBoxProxyPassword.PasswordChar = '*';
-            this.textBoxProxyPassword.Size = new System.Drawing.Size(313, 29);
+            this.textBoxProxyPassword.Size = new System.Drawing.Size(229, 22);
             this.textBoxProxyPassword.TabIndex = 34;
             // 
             // labelProxyUsername
             // 
             this.labelProxyUsername.AutoSize = true;
-            this.labelProxyUsername.Location = new System.Drawing.Point(34, 360);
-            this.labelProxyUsername.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelProxyUsername.Location = new System.Drawing.Point(25, 240);
             this.labelProxyUsername.Name = "labelProxyUsername";
-            this.labelProxyUsername.Size = new System.Drawing.Size(108, 25);
+            this.labelProxyUsername.Size = new System.Drawing.Size(77, 17);
             this.labelProxyUsername.TabIndex = 31;
             this.labelProxyUsername.Text = "Username:";
             // 
             // labelProxyPassword
             // 
             this.labelProxyPassword.AutoSize = true;
-            this.labelProxyPassword.Location = new System.Drawing.Point(34, 420);
-            this.labelProxyPassword.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelProxyPassword.Location = new System.Drawing.Point(25, 280);
             this.labelProxyPassword.Name = "labelProxyPassword";
-            this.labelProxyPassword.Size = new System.Drawing.Size(104, 25);
+            this.labelProxyPassword.Size = new System.Drawing.Size(73, 17);
             this.labelProxyPassword.TabIndex = 32;
             this.labelProxyPassword.Text = "Password:";
             // 
@@ -958,10 +950,10 @@ namespace EsOdbcDsnEditor
             this.checkProxyAuthEnabled.AutoSize = true;
             this.checkProxyAuthEnabled.Checked = true;
             this.checkProxyAuthEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkProxyAuthEnabled.Location = new System.Drawing.Point(25, 294);
-            this.checkProxyAuthEnabled.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkProxyAuthEnabled.Location = new System.Drawing.Point(18, 196);
+            this.checkProxyAuthEnabled.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkProxyAuthEnabled.Name = "checkProxyAuthEnabled";
-            this.checkProxyAuthEnabled.Size = new System.Drawing.Size(228, 29);
+            this.checkProxyAuthEnabled.Size = new System.Drawing.Size(168, 21);
             this.checkProxyAuthEnabled.TabIndex = 30;
             this.checkProxyAuthEnabled.Text = "Enable Authentication";
             this.checkProxyAuthEnabled.UseVisualStyleBackColor = true;
@@ -977,56 +969,52 @@ namespace EsOdbcDsnEditor
             "SOCKS4a",
             "SOCKS5",
             "SOCKS5h"});
-            this.comboBoxProxyType.Location = new System.Drawing.Point(166, 100);
-            this.comboBoxProxyType.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxProxyType.Location = new System.Drawing.Point(121, 67);
+            this.comboBoxProxyType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxProxyType.Name = "comboBoxProxyType";
-            this.comboBoxProxyType.Size = new System.Drawing.Size(147, 32);
+            this.comboBoxProxyType.Size = new System.Drawing.Size(108, 24);
             this.comboBoxProxyType.TabIndex = 29;
             this.comboBoxProxyType.SelectedIndexChanged += new System.EventHandler(this.ComboBoxProxyType_SelectedIndexChanged);
             // 
             // labelProxyType
             // 
             this.labelProxyType.AutoSize = true;
-            this.labelProxyType.Location = new System.Drawing.Point(34, 107);
-            this.labelProxyType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelProxyType.Location = new System.Drawing.Point(25, 71);
             this.labelProxyType.Name = "labelProxyType";
-            this.labelProxyType.Size = new System.Drawing.Size(63, 25);
+            this.labelProxyType.Size = new System.Drawing.Size(44, 17);
             this.labelProxyType.TabIndex = 28;
             this.labelProxyType.Text = "Type:";
             // 
             // textProxyHostname
             // 
-            this.textProxyHostname.Location = new System.Drawing.Point(166, 165);
-            this.textProxyHostname.Margin = new System.Windows.Forms.Padding(6);
+            this.textProxyHostname.Location = new System.Drawing.Point(121, 110);
+            this.textProxyHostname.Margin = new System.Windows.Forms.Padding(4);
             this.textProxyHostname.MaxLength = 512;
             this.textProxyHostname.Name = "textProxyHostname";
-            this.textProxyHostname.Size = new System.Drawing.Size(658, 29);
+            this.textProxyHostname.Size = new System.Drawing.Size(480, 22);
             this.textProxyHostname.TabIndex = 26;
             // 
             // labelProxyHostname
             // 
             this.labelProxyHostname.AutoSize = true;
-            this.labelProxyHostname.Location = new System.Drawing.Point(34, 170);
-            this.labelProxyHostname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelProxyHostname.Location = new System.Drawing.Point(25, 113);
             this.labelProxyHostname.Name = "labelProxyHostname";
-            this.labelProxyHostname.Size = new System.Drawing.Size(107, 25);
+            this.labelProxyHostname.Size = new System.Drawing.Size(76, 17);
             this.labelProxyHostname.TabIndex = 24;
             this.labelProxyHostname.Text = "Hostname:";
             // 
             // labelProxyPort
             // 
             this.labelProxyPort.AutoSize = true;
-            this.labelProxyPort.Location = new System.Drawing.Point(34, 225);
-            this.labelProxyPort.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelProxyPort.Location = new System.Drawing.Point(25, 150);
             this.labelProxyPort.Name = "labelProxyPort";
-            this.labelProxyPort.Size = new System.Drawing.Size(53, 25);
+            this.labelProxyPort.Size = new System.Drawing.Size(38, 17);
             this.labelProxyPort.TabIndex = 25;
             this.labelProxyPort.Text = "Port:";
             // 
             // numericUpDownProxyPort
             // 
-            this.numericUpDownProxyPort.Location = new System.Drawing.Point(166, 223);
-            this.numericUpDownProxyPort.Margin = new System.Windows.Forms.Padding(4);
+            this.numericUpDownProxyPort.Location = new System.Drawing.Point(121, 149);
             this.numericUpDownProxyPort.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -1038,7 +1026,7 @@ namespace EsOdbcDsnEditor
             0,
             0});
             this.numericUpDownProxyPort.Name = "numericUpDownProxyPort";
-            this.numericUpDownProxyPort.Size = new System.Drawing.Size(143, 29);
+            this.numericUpDownProxyPort.Size = new System.Drawing.Size(104, 22);
             this.numericUpDownProxyPort.TabIndex = 27;
             this.numericUpDownProxyPort.Value = new decimal(new int[] {
             1080,
@@ -1051,10 +1039,10 @@ namespace EsOdbcDsnEditor
             this.checkProxyEnabled.AutoSize = true;
             this.checkProxyEnabled.Checked = true;
             this.checkProxyEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkProxyEnabled.Location = new System.Drawing.Point(25, 32);
-            this.checkProxyEnabled.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.checkProxyEnabled.Location = new System.Drawing.Point(18, 21);
+            this.checkProxyEnabled.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkProxyEnabled.Name = "checkProxyEnabled";
-            this.checkProxyEnabled.Size = new System.Drawing.Size(154, 29);
+            this.checkProxyEnabled.Size = new System.Drawing.Size(113, 21);
             this.checkProxyEnabled.TabIndex = 23;
             this.checkProxyEnabled.Text = "Enable Proxy";
             this.checkProxyEnabled.UseVisualStyleBackColor = true;
@@ -1062,9 +1050,9 @@ namespace EsOdbcDsnEditor
             // 
             // DsnEditorForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(938, 882);
+            this.ClientSize = new System.Drawing.Size(682, 588);
             this.Controls.Add(this.tabConfiguration);
             this.Controls.Add(this.header);
             this.Controls.Add(this.testButton);
@@ -1072,7 +1060,7 @@ namespace EsOdbcDsnEditor
             this.Controls.Add(this.saveButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(6);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "DsnEditorForm";
@@ -1212,6 +1200,9 @@ namespace EsOdbcDsnEditor
 		private System.Windows.Forms.ToolTip toolTipProxyAuthEnabled;
 		private System.Windows.Forms.ToolTip toolTipProxyUsername;
 		private System.Windows.Forms.ToolTip toolTipProxyPassword;
+		private System.Windows.Forms.TextBox textApiKey;
+		private System.Windows.Forms.Label labelApiKey;
+		private System.Windows.Forms.ToolTip toolTipApiKey;
 	}
 }
 

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -66,6 +66,7 @@ namespace EsOdbcDsnEditor
 			textDescription.Text = Builder.ContainsKey("description") ? Builder["description"].ToString().StripBraces() : string.Empty;
 			textUsername.Text = Builder.ContainsKey("uid") ? Builder["uid"].ToString().StripBraces() : string.Empty;
 			textPassword.Text = Builder.ContainsKey("pwd") ? Builder["pwd"].ToString().StripBraces() : string.Empty;
+			textApiKey.Text = Builder.ContainsKey("apikey") ? Builder["apikey"].ToString().StripBraces() : string.Empty;
 			textCloudID.Text = Builder.ContainsKey("cloudid") ? Builder["cloudid"].ToString().StripBraces() : string.Empty;
 			textHostname.Text = Builder.ContainsKey("server") ? Builder["server"].ToString().StripBraces() : string.Empty;
 			numericUpDownPort.Text = Builder.ContainsKey("port") ? Builder["port"].ToString().StripBraces() : string.Empty;
@@ -77,6 +78,7 @@ namespace EsOdbcDsnEditor
 			toolTipPort.SetToolTip(numericUpDownPort, "The port which the Elasticsearch listens on.");
 			toolTipUsername.SetToolTip(textUsername, "If security is enabled, the username configured to access the REST SQL endpoint.");
 			toolTipPassword.SetToolTip(textPassword, "If security is enabled, the password configured to access the REST SQL endpoint.");
+			toolTipApiKey.SetToolTip(textApiKey, "If security is enabled, the API Key configured to access the REST SQL endpoint.");
 
 			// Security Panel
 			textCertificatePath.Text = Builder.ContainsKey("capath") ? Builder["capath"].ToString().StripBraces() : string.Empty;
@@ -286,6 +288,7 @@ namespace EsOdbcDsnEditor
 			// (trailing) white space by mistake than intentionally trying to set it.
 			Builder["uid"] = textUsername.Text.Trim();
 			Builder["pwd"] = textPassword.Text;
+			Builder["apikey"] = textApiKey.Text;
 			Builder["cloudid"] = "{" + textCloudID.Text.StripBraces().Trim() + "}";
 			Builder["server"] = textHostname.Text.Trim();
 			Builder["port"] = numericUpDownPort.Text;
@@ -415,6 +418,12 @@ namespace EsOdbcDsnEditor
 
 		private void TextCloudID_TextChanged(object sender, EventArgs e) => EnableDisableActionButtons();
 
+		private void TextUsername_TextChanged(object sender, EventArgs e) => EnableDisableActionButtons();
+
+		private void TextPassword_TextChanged(object sender, EventArgs e) => EnableDisableActionButtons();
+
+		private void TextApiKey_TextChanged(object sender, EventArgs e) => EnableDisableActionButtons();
+
 		private void NumericUpDownPort_ValueChanged(object sender, EventArgs e) => EnableDisableActionButtons();
 
 		private void CheckLoggingEnabled_CheckedChanged(object sender, EventArgs e) => EnableDisableLoggingControls();
@@ -449,6 +458,16 @@ namespace EsOdbcDsnEditor
 			textHostname.Enabled = numericUpDownPort.Enabled
 				= textCertificatePath.Enabled = certificatePathButton.Enabled
 				= string.IsNullOrEmpty(textCloudID.Text);
+
+			if (string.IsNullOrEmpty(textApiKey.Text) == false) {
+				textUsername.ResetText();
+				Builder.Remove("uid");
+				textPassword.ResetText();
+				Builder.Remove("pwd");
+			}
+
+			textApiKey.Enabled = string.IsNullOrEmpty(textUsername.Text) && string.IsNullOrEmpty(textPassword.Text);
+			textUsername.Enabled = textPassword.Enabled = string.IsNullOrEmpty(textApiKey.Text);
 
 			if (isConnecting) {
 				// If connecting, enable the button if we have a hostname.

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.cs
@@ -78,7 +78,7 @@ namespace EsOdbcDsnEditor
 			toolTipPort.SetToolTip(numericUpDownPort, "The port which the Elasticsearch listens on.");
 			toolTipUsername.SetToolTip(textUsername, "If security is enabled, the username configured to access the REST SQL endpoint.");
 			toolTipPassword.SetToolTip(textPassword, "If security is enabled, the password configured to access the REST SQL endpoint.");
-			toolTipApiKey.SetToolTip(textApiKey, "If security is enabled, the API Key configured to access the REST SQL endpoint.");
+			toolTipApiKey.SetToolTip(textApiKey, "If security is enabled, the Base64-encoded API key credentials configured to access the REST SQL endpoint.");
 
 			// Security Panel
 			textCertificatePath.Text = Builder.ContainsKey("capath") ? Builder["capath"].ToString().StripBraces() : string.Empty;

--- a/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
+++ b/dsneditor/EsOdbcDsnEditor/DSNEditorForm.resx
@@ -2754,97 +2754,121 @@
 </value>
   </data>
   <metadata name="certificateFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>228, 60</value>
   </metadata>
   <metadata name="folderLogDirectoryDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>239, 17</value>
+    <value>418, 60</value>
   </metadata>
   <metadata name="toolTipName.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>507, 17</value>
+    <value>647, 60</value>
   </metadata>
   <metadata name="toolTipDescription.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>675, 17</value>
+    <value>792, 60</value>
   </metadata>
   <metadata name="toolTipCloudID.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>181, 161</value>
+    <value>1006, 146</value>
   </metadata>
   <metadata name="toolTipHostname.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>887, 17</value>
+    <value>974, 60</value>
   </metadata>
   <metadata name="toolTipPort.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1090, 17</value>
+    <value>1148, 60</value>
   </metadata>
   <metadata name="toolTipUsername.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>695, 65</value>
+    <value>597, 103</value>
   </metadata>
   <metadata name="toolTipPassword.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>499, 65</value>
+    <value>428, 103</value>
   </metadata>
   <metadata name="toolTipDisabled.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>309, 65</value>
+    <value>265, 103</value>
   </metadata>
   <metadata name="toolTipEnabledNoValidation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 65</value>
+    <value>17, 103</value>
   </metadata>
   <metadata name="toolTipEnabledNoHostname.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>896, 65</value>
+    <value>770, 103</value>
   </metadata>
   <metadata name="toolTipEnabledHostname.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 113</value>
+    <value>1019, 103</value>
   </metadata>
   <metadata name="toolTipEnabledFull.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>285, 113</value>
+    <value>17, 146</value>
   </metadata>
   <metadata name="toolTipCertificatePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>498, 113</value>
+    <value>200, 146</value>
   </metadata>
   <metadata name="toolTipLogDirectoryPath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>736, 113</value>
+    <value>404, 146</value>
   </metadata>
   <metadata name="toolTipLoggingEnabled.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>997, 113</value>
+    <value>627, 146</value>
   </metadata>
   <metadata name="toolTipLogLevel.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 161</value>
+    <value>842, 146</value>
   </metadata>
   <metadata name="toolTipTimeout.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>341, 161</value>
+    <value>1166, 146</value>
   </metadata>
   <metadata name="toolTipFetchSize.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>454, 161</value>
+    <value>17, 189</value>
   </metadata>
   <metadata name="toolTipBodySize.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>619, 163</value>
+    <value>185, 189</value>
   </metadata>
   <metadata name="toolTipFloatsFormat.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>774, 165</value>
+    <value>351, 189</value>
   </metadata>
   <metadata name="toolTipFollowRedirects.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>960, 162</value>
+    <value>544, 189</value>
   </metadata>
   <metadata name="toolTipApplyTZ.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>31, 212</value>
+    <value>755, 189</value>
   </metadata>
   <metadata name="toolTipAutoEscapePVA.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>187, 214</value>
+    <value>916, 189</value>
   </metadata>
   <metadata name="toolTipMultiFieldLenient.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>399, 213</value>
+    <value>1128, 189</value>
   </metadata>
   <metadata name="toolTipIndexIncludeFrozen.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>617, 213</value>
+    <value>17, 232</value>
   </metadata>
   <metadata name="toolTipDataEncoding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>854, 213</value>
+    <value>254, 232</value>
   </metadata>
   <metadata name="toolTipDataCompression.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1046, 215</value>
+    <value>454, 232</value>
   </metadata>
   <metadata name="toolTipEarlyExecution.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>173, 265</value>
+    <value>869, 232</value>
   </metadata>
   <metadata name="toolTipVarcharLimit.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>29, 265</value>
+    <value>679, 232</value>
+  </metadata>
+  <metadata name="toolTipProxyEnabled.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1009, 17</value>
+  </metadata>
+  <metadata name="toolTipProxyType.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>834, 17</value>
+  </metadata>
+  <metadata name="toolTipProxyHostname.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>622, 17</value>
+  </metadata>
+  <metadata name="toolTipProxyPort.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>452, 17</value>
+  </metadata>
+  <metadata name="toolTipProxyAuthEnabled.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>223, 17</value>
+  </metadata>
+  <metadata name="toolTipProxyUsername.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 60</value>
+  </metadata>
+  <metadata name="toolTipProxyPassword.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTipApiKey.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1071, 232</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>354</value>

--- a/test/integration/elasticsearch.py
+++ b/test/integration/elasticsearch.py
@@ -307,4 +307,13 @@ class Elasticsearch(object):
 	def is_listening(self):
 		return self.cluster_name(False) is not None
 
+	def api_key(self):
+		resp = self._req.post("%s/_security/api_key" % self._base_url, auth=self._credentials,
+				timeout=self.REQ_TIMEOUT, json={"name": "test-api-key"})
+		if resp.status_code != 200:
+			raise Exception("API key generation request failed with code: %s" % resp.status_code)
+		if "encoded" not in resp.json():
+			raise Exception("missing 'encoded' key in ES answer: %s" % resp.text)
+		return resp.json().get("encoded")
+
 # vim: set noet fenc=utf-8 ff=dos sts=0 sw=4 ts=4 tw=118 :


### PR DESCRIPTION
This adds support for authenticating using API Keys.

The DSN editor has been updated to take a new "API Key" field. This field is enabled iif no Username and Password are provided. The field is stored in the DSN string and then used in every request for respective configured connection.