### PR TITLE
Fix version qualifier setting in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,13 @@ set(DRIVER_BASE_NAME elasticodbc CACHE STRING
 
 # driver's version
 set(DRV_VERSION 9.0.0)
-set(VERSION_QUALIFIER -$ENV{VERSION_QUALIFIER} CACHE STRING
-	"Extra string to append to the install directory name")
+if(DEFINED ENV{VERSION_QUALIFIER})
+	set(VERSION_QUALIFIER -$ENV{VERSION_QUALIFIER} CACHE STRING
+		"Extra string to append to the install directory name")
+else()
+	set(VERSION_QUALIFIER "" CACHE STRING
+		"Extra string to append to the install directory name")
+endif()
 
 # build a UNICODE driver? (the only supported way currently)
 set(IS_UNICODE 1)


### PR DESCRIPTION
(cherry picked from commit 61edba468647a60425cab4a5fba3b77d992873a1)

# Conflicts:
#	CMakeLists.txt