### PR TITLE
update pipeline setting

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -134,6 +134,7 @@ spec:
       name: elasticsearch-sql-odbc-version-bump
     spec:
       pipeline_file: ".buildkite/pipeline.version.bump.yml"
+      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
       repository: elastic/elasticsearch-sql-odbc


### PR DESCRIPTION
Hi Team,

This is a follow up to an existing PR: https://github.com/elastic/elasticsearch-sql-odbc/pull/343

By default `skip_intermediate_builds` is true. In an event that there are parallel version bumps, it would cancel the queued builds in the version bump pipeline.

This PR disables skipping intermediate builds.